### PR TITLE
feat: add AGENTS.md and docs/architecture.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,61 @@
+# AGENTS.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+このファイルはコーディングエージェントのためのクイックリファレンスです。詳細はdocs/を参照してください。
+
+## Overview
+
+Nix Flakes ベースの macOS (aarch64-darwin) dotfiles リポジトリ。nix-darwin と home-manager を使い、システム設定からユーザー環境まで宣言的に管理する。
+
+## Build Commands
+
+```bash
+# flake.lock の更新
+nix flake update
+
+# システム全体の再ビルド・適用
+darwin-rebuild switch --flake .#M4MacBookAir
+
+# ビルドのみ (適用しない)
+darwin-rebuild build --flake .#M4MacBookAir
+
+# テストビルド (適用しない、プロファイルにも追加しない)
+darwin-rebuild test --flake .#M4MacBookAir
+
+# Nix コードのフォーマット
+alejandra .
+```
+
+## Architecture
+
+エントリーポイントは `flake.nix` で、主要な構成要素は以下の 3 層になっている。
+
+- `hosts/` はホスト固有の設定 (hostname, user) を置く場所
+- `modules/` は nix-darwin のシステム設定 (firewall, keyboard, dock 等) をまとめる場所
+- `home/` は home-manager によるユーザー環境で、`base/` が全プラットフォーム共通、`darwin/` がプラットフォーム固有
+
+詳細は [docs/architecture.md](docs/architecture.md) を参照。
+
+## Key Design Decisions
+
+- nixpkgs は unstable ブランチを使用している
+- Neovim nightly は neovim-nightly-overlay 経由で取得し、`flake.nix` の packages として公開している
+- 1Password が SSH agent と Git の GPG 署名を担っている
+- Docker ランタイムには colima を使用している
+- パッケージ一覧は `home/base/programs/default.nix` に集約している
+- Nix コードのフォーマットには alejandra を使用している
+
+## Conventions
+
+- Nix モジュールを追加したら、対応する `default.nix` の imports にも追加する
+- ホスト固有の設定は `hosts/<hostname>/` に配置する
+- プラットフォーム共通の設定は `home/base/` に、プラットフォーム固有の設定は `home/darwin/` に配置する
+- `flake.lock` は `.gitignore` で除外されている
+
+## Writing Rules
+
+ドキュメントやコメントを書くときは以下のルールを守ること。
+
+- 日本語として自然な文章で書く。体言止めや電報的な箇条書きは避け、述語のある文にする
+- Markdown の太字強調 (`**...**`) は使わない。強調が必要な場合はバッククォートやそのままの表現で十分に伝わるよう工夫する
+- 図を描きたいときは ASCII art ではなく mermaid を使う

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,44 @@
+# Architecture
+
+## モジュール依存関係
+
+```mermaid
+graph TD
+    A[flake.nix] --> B[hosts/M4MacBookAir/default.nix]
+    B --> C[modules/darwin/default.nix]
+    C --> D[modules/default.nix]
+    C --> E[modules/darwin/system.nix]
+    B --> F[home/darwin/default.nix]
+    F --> G[home/base/default.nix]
+    G --> H[editor/neovim/]
+    G --> I[programs/]
+    G --> J[shell/zsh/]
+    G --> K[terminal/tmux/]
+```
+
+## 各層の役割
+
+### flake.nix
+
+リポジトリ全体のエントリーポイントにあたる。nixpkgs, nix-darwin, home-manager, neovim-nightly-overlay などの inputs を定義し、darwinConfigurations を出力する。
+
+### hosts/
+
+マシンごとの設定を置く場所。hostname やユーザー名、home-manager との接続を定義する。新しいマシンを追加するときは `hosts/<hostname>/default.nix` を作成し、`flake.nix` の darwinConfigurations にエントリーを追加する。
+
+### modules/
+
+nix-darwin のシステムレベル設定をまとめている。`modules/default.nix` は Nix 自体の基本設定 (flakes 有効化、unfree 許可、タイムゾーン) を担当し、`modules/darwin/system.nix` は macOS 固有のシステム設定 (firewall, keyboard remap, dock, finder 等) を担当する。
+
+### home/base/
+
+全プラットフォーム共通のユーザー環境設定を置く場所で、以下のサブモジュールを持つ。
+
+- `editor/neovim/` は Neovim nightly に LSP (gopls, nil, rust-analyzer, typescript-language-server) と Copilot、各種プラグインを組み合わせた設定を管理している
+- `programs/` はパッケージ一覧 (`default.nix`) と、git, direnv, mise, skim, ssh といった個別ツールの設定を管理している
+- `shell/zsh/` は Zsh の設定と ghq-skim, gwt-skim プラグインを管理している
+- `terminal/tmux/` は Tmux の設定を管理している (prefix は C-q)
+
+### home/darwin/
+
+darwin 固有の home-manager 設定を置く場所。state version と linkapps の設定を行い、`home/base/` を import している。

--- a/docs/non-flake-tools.md
+++ b/docs/non-flake-tools.md
@@ -1,0 +1,40 @@
+# Nix Flake 管理外のツール
+
+このドキュメントでは、nix flake (`flake.nix`) の管理外で別途インストールが必要なツールを列挙する。
+
+## 1Password
+
+- 用途: パスワードマネージャー / SSH エージェント / Git コミット署名
+- 詳細: SSH 秘密鍵を 1Password 内に保管し、SSH エージェントとして動作する。秘密鍵がアプリ外に出ることなく Touch ID で認証できる。Git の GPG 署名 (SSH 形式) にも対応
+- 公式: https://1password.com/
+- インストール: macOS アプリとして手動インストール
+- 設定箇所:
+  - `home/base/programs/ssh/default.nix` (SSH Identity Agent)
+  - `home/base/programs/git/default.nix` (GPG 署名)
+
+## Google Chrome
+
+- 用途: Web ブラウザ
+- 公式: https://www.google.com/chrome/
+- インストール: macOS アプリとして手動インストール
+
+## Choosy
+
+- 用途: macOS のデフォルトブラウザとして設定し、リンクを開く際にルールベースで使用するブラウザやプロファイルを振り分ける
+- 詳細: URL パターンなどの条件に基づいてリンクを開くブラウザ / プロファイルを自動選択できる。Google Chrome、Microsoft Edge、Brave、Vivaldi のプロファイル選択に対応
+- 公式: https://choosy.app/
+- インストール: macOS アプリとして手動インストール
+
+## Ghostty
+
+- 用途: GPU アクセラレーション対応のターミナルエミュレータ
+- 詳細: macOS では Metal によるGPU レンダリングを使用。プラットフォームネイティブな UI、タブ・分割ペイン、Kitty graphics/keyboard protocol、Nerd Fonts のビルトインサポートなどを備える
+- 公式: https://ghostty.org/
+- インストール: macOS アプリとして手動インストール
+
+## Karabiner-Elements
+
+- 用途: macOS 向けキーボードカスタマイズツール
+- 詳細: キーの単純なリマップ (Simple Modifications) と、条件付きの複雑なルール (Complex Modifications) に対応。特定のキーボードのみへの適用や複数プロファイルの切り替えが可能。Intel / Apple Silicon 両対応
+- 公式: https://karabiner-elements.pqrs.org/
+- インストール: macOS アプリとして手動インストール


### PR DESCRIPTION
## Summary
- コーディングエージェント向けのクイックリファレンスとして AGENTS.md を追加した
- モジュール依存関係や各層の役割を記述した docs/architecture.md を追加した
- ドキュメントの作業ルール (自然な日本語、太字禁止、mermaid 使用) を定めた

## Test plan
- [ ] AGENTS.md の内容がリポジトリの実態と一致していることを確認する
- [ ] docs/architecture.md の mermaid 図が GitHub 上で正しくレンダリングされることを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)