### PR TITLE
refactor: dotfiles設定の最適化とモジュール分割

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,9 +8,10 @@ graph TD
     B --> C[modules/darwin/default.nix]
     C --> D[modules/default.nix]
     C --> E[modules/darwin/system.nix]
-    B --> F[home/darwin/default.nix]
+    A --> F[home/darwin/default.nix]
     F --> G[home/base/default.nix]
     G --> H[editor/neovim/]
+    H --> L[neovim/plugins/]
     G --> I[programs/]
     G --> J[shell/zsh/]
     G --> K[terminal/tmux/]
@@ -34,7 +35,7 @@ nix-darwin のシステムレベル設定をまとめている。`modules/defaul
 
 全プラットフォーム共通のユーザー環境設定を置く場所で、以下のサブモジュールを持つ。
 
-- `editor/neovim/` は Neovim nightly に LSP (gopls, nil, rust-analyzer, typescript-language-server) と Copilot、各種プラグインを組み合わせた設定を管理している
+- `editor/neovim/` は Neovim nightly に LSP (gopls, nil, rust-analyzer, typescript-language-server) と Copilot、各種プラグインを組み合わせた設定を管理している。プラグイン定義は `plugins/` サブディレクトリに分割されており、ui, completion, lsp, tools の 4 カテゴリで構成されている
 - `programs/` はパッケージ一覧 (`default.nix`) と、git, direnv, mise, skim, ssh といった個別ツールの設定を管理している
 - `shell/zsh/` は Zsh の設定と ghq-skim, gwt-skim プラグインを管理している
 - `terminal/tmux/` は Tmux の設定を管理している (prefix は C-q)

--- a/flake.nix
+++ b/flake.nix
@@ -9,10 +9,6 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    flake-utils = {
-      url = "github:numtide/flake-utils";
-    };
-
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -28,42 +24,36 @@
     self,
     nixpkgs,
     nix-darwin,
-    flake-utils,
     home-manager,
     neovim,
     ...
   } @ inputs: let
     inherit (self) outputs;
-  in
-    flake-utils.lib.eachDefaultSystem (system: {
-      packages = {
-        neovim = inputs.neovim.packages.${system}.default;
-      };
-    })
-    // {
-      nixConfig = {
-        extra-substituters = [
-          "https://nix-community.cachix.org"
+  in {
+    nixConfig = {
+      extra-substituters = [
+        "https://nix-community.cachix.org"
+      ];
+      extra-trusted-public-keys = [
+        "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+      ];
+    };
+    packages.aarch64-darwin.neovim = inputs.neovim.packages.aarch64-darwin.default;
+    darwinConfigurations = {
+      M4MacBookAir = nix-darwin.lib.darwinSystem {
+        system = "aarch64-darwin";
+        modules = [
+          ./hosts/M4MacBookAir
+          home-manager.darwinModules.home-manager
+          {
+            home-manager.useGlobalPkgs = true;
+            home-manager.users.pranc1ngpegasus = import ./home/darwin;
+          }
         ];
-        extra-trusted-public-keys = [
-          "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-        ];
-      };
-      darwinConfigurations = {
-        M4MacBookAir = nix-darwin.lib.darwinSystem {
-          system = "aarch64-darwin";
-          modules = [
-            ./hosts/M4MacBookAir
-            home-manager.darwinModules.home-manager
-            {
-              home-manager.useGlobalPkgs = true;
-              home-manager.users.pranc1ngpegasus = import ./home/darwin;
-            }
-          ];
-          specialArgs = {
-            inherit inputs outputs;
-          };
+        specialArgs = {
+          inherit inputs outputs;
         };
       };
     };
+  };
 }

--- a/home/base/editor/neovim/default.nix
+++ b/home/base/editor/neovim/default.nix
@@ -1,54 +1,45 @@
 {pkgs, ...}: {
-  home.packages = with pkgs; [
-    gopls
-    nil
-    rust-analyzer
-    typescript-language-server
+  imports = [
+    ./plugins
   ];
+
   programs.neovim = {
     enable = true;
     defaultEditor = true;
     vimAlias = true;
-    extraConfig = ''
-      " options
-      set autoread
-      set background=dark
-      set clipboard=unnamed
-      set cmdheight=0
-      set cursorcolumn
-      set cursorline
-      set encoding=UTF-8
-      set expandtab
-      set ignorecase
-      set inccommand=split
-      set incsearch
-      set laststatus=0
-      set nobackup
-      set noshowmode
-      set noswapfile
-      set number
-      set scrolloff=1000
-      set shiftround
-      set shiftwidth=2
-      set smartcase
-      set smartindent
-      set tabstop=2
-      set termguicolors
-      set wrapscan
-
-      " netrw
-      let g:netrw_liststyle = 3
-      let g:netrw_preview = 1
-      let g:netrw_sizestyle = "H"
-      let g:netrw_timefmt = "%Y/%m/%d(%a) %H:%M:%S"
-
-      " truecolor
-      if !has('gui_running') && &term =~ '^\%(screen\|tmux\)'
-        let &t_8f = "\<Esc>[38;2;%lu;%lu;%lum"
-        let &t_8b = "\<Esc>[48;2;%lu;%lu;%lum"
-      endif
-    '';
     extraLuaConfig = ''
+      -- options
+      vim.opt.autoread = true
+      vim.opt.background = "dark"
+      vim.opt.clipboard = "unnamed"
+      vim.opt.cmdheight = 0
+      vim.opt.cursorcolumn = true
+      vim.opt.cursorline = true
+      vim.opt.encoding = "UTF-8"
+      vim.opt.expandtab = true
+      vim.opt.ignorecase = true
+      vim.opt.inccommand = "split"
+      vim.opt.incsearch = true
+      vim.opt.laststatus = 0
+      vim.opt.backup = false
+      vim.opt.showmode = false
+      vim.opt.swapfile = false
+      vim.opt.number = true
+      vim.opt.scrolloff = 1000
+      vim.opt.shiftround = true
+      vim.opt.shiftwidth = 2
+      vim.opt.smartcase = true
+      vim.opt.smartindent = true
+      vim.opt.tabstop = 2
+      vim.opt.termguicolors = true
+      vim.opt.wrapscan = true
+
+      -- netrw
+      vim.g.netrw_liststyle = 3
+      vim.g.netrw_preview = 1
+      vim.g.netrw_sizestyle = "H"
+      vim.g.netrw_timefmt = "%Y/%m/%d(%a) %H:%M:%S"
+
       -- disable unnecessary built-in plugins
       vim.g.did_indent_on             = 1
       vim.g.did_install_default_menus = 1
@@ -75,166 +66,5 @@
       vim.g.loaded_zipPlugin          = 1
       vim.g.skip_loading_mswin        = 1
     '';
-    plugins = with pkgs.vimPlugins; [
-      # theme
-      {
-        plugin = iceberg-vim;
-        type = "viml";
-        config = ''
-          colorscheme iceberg
-        '';
-      }
-      # show key bindings
-      {
-        plugin = which-key-nvim;
-        type = "lua";
-        config = ''
-          vim.keymap.set('n', '<leader>?', '<cmd>lua require("which-key").show({global = false})<CR>')
-        '';
-      }
-      # statusline
-      {
-        plugin = incline-nvim;
-        type = "lua";
-        config = ''
-          require('incline').setup()
-        '';
-      }
-      # notify
-      {
-        plugin = nvim-notify;
-        type = "lua";
-        config = ''
-          require("notify").setup({
-            max_width = 50,
-            render = "wrapped-compact",
-            stages = "slide",
-            timeout = 1500,
-          })
-        '';
-      }
-      nui-nvim
-      {
-        plugin = noice-nvim;
-        type = "lua";
-        config = ''
-          require("noice").setup()
-        '';
-      }
-      # completion
-      {
-        plugin = copilot-lua;
-        type = "lua";
-        config = ''
-          require("copilot").setup({
-            suggestion = {
-              enabled = false,
-            },
-            panel = {
-              enabled = false,
-            },
-          })
-        '';
-      }
-      blink-cmp-copilot
-      {
-        plugin = blink-cmp;
-        type = "lua";
-        config = ''
-          require('blink-cmp').setup({
-            completion = {
-              accept = {
-                auto_brackets = {
-                  enabled = true,
-                },
-              },
-              documentation = {
-                auto_show = true,
-                auto_show_delay_ms = 500,
-              },
-              keyword = {
-                range = 'full',
-              },
-              list = {
-                selection = {
-                  preselect = false,
-                  auto_insert = true,
-                },
-              },
-              menu = {
-                auto_show = true,
-              },
-              ghost_text = {
-                enabled = true,
-              },
-            },
-            keymap = {
-              preset = 'default',
-            },
-            signature = {
-              enabled = true,
-            },
-            sources = {
-              default = {
-                'lsp',
-                'path',
-                'snippets',
-                'buffer',
-                'copilot',
-              },
-              providers = {
-                copilot = {
-                  name = "copilot",
-                  module = "blink-cmp-copilot",
-                  score_offset = 100,
-                  async = true,
-                },
-              },
-            },
-          })
-        '';
-      }
-      {
-        plugin = nvim-lspconfig;
-        type = "lua";
-        config = ''
-          local servers = {"rust_analyzer", "gopls", "ts_ls", "nil_ls"};
-          local opt = {
-            on_attach = function(client, bufnr)
-              local opts = { noremap = true, silent = true }
-              vim.api.nvim_buf_set_keymap(bufnr, 'n', 'ca', '<cmd>lua vim.lsp.buf.code_action()<CR>', opts)
-              vim.api.nvim_buf_set_keymap(bufnr, 'n', 'gc', '<cmd>lua vim.lsp.buf.incoming_calls()<CR>', opts)
-              vim.api.nvim_buf_set_keymap(bufnr, 'n', 'go', '<cmd>lua vim.lsp.buf.outgoing_calls()<CR>', opts)
-              vim.api.nvim_buf_set_keymap(bufnr, 'n', 'gd', '<cmd>lua vim.lsp.buf.definition()<CR>', opts)
-              vim.api.nvim_buf_set_keymap(bufnr, 'n', 'gf', '<cmd>lua vim.lsp.buf.references()<CR>', opts)
-              vim.api.nvim_buf_set_keymap(bufnr, 'n', 'gi', '<cmd>lua vim.lsp.buf.implementation()<CR>', opts)
-              vim.api.nvim_buf_set_keymap(bufnr, 'n', 'gr', '<cmd>lua vim.lsp.buf.rename()<CR>', opts)
-              vim.cmd 'autocmd BufWritePre * lua vim.lsp.buf.format({ async = false, timeout_ms = 1000 })'
-            end,
-            capabilities = require('blink-cmp').get_lsp_capabilities()
-          }
-
-          for _, server in ipairs(servers) do
-            require('lspconfig')[server].setup(opt)
-          end
-        '';
-      }
-      {
-        plugin = telescope-nvim;
-        type = "lua";
-        config = ''
-          vim.keymap.set('n', '<Space><Space>', '<cmd>Telescope find_files<CR>', { noremap = true, silent = true })
-          vim.keymap.set('n', '<C-f>', '<cmd>Telescope live_grep<CR>', { noremap = true, silent = true })
-        '';
-      }
-      nvim-treesitter.withAllGrammars
-      {
-        plugin = gitlinker-nvim;
-        type = "lua";
-        config = ''
-          require("gitlinker").setup()
-        '';
-      }
-    ];
   };
 }

--- a/home/base/editor/neovim/plugins/completion.nix
+++ b/home/base/editor/neovim/plugins/completion.nix
@@ -1,0 +1,76 @@
+{pkgs, ...}: {
+  programs.neovim.plugins = with pkgs.vimPlugins; [
+    {
+      plugin = copilot-lua;
+      type = "lua";
+      config = ''
+        require("copilot").setup({
+          suggestion = {
+            enabled = false,
+          },
+          panel = {
+            enabled = false,
+          },
+        })
+      '';
+    }
+    blink-cmp-copilot
+    {
+      plugin = blink-cmp;
+      type = "lua";
+      config = ''
+        require('blink-cmp').setup({
+          completion = {
+            accept = {
+              auto_brackets = {
+                enabled = true,
+              },
+            },
+            documentation = {
+              auto_show = true,
+              auto_show_delay_ms = 500,
+            },
+            keyword = {
+              range = 'full',
+            },
+            list = {
+              selection = {
+                preselect = false,
+                auto_insert = true,
+              },
+            },
+            menu = {
+              auto_show = true,
+            },
+            ghost_text = {
+              enabled = true,
+            },
+          },
+          keymap = {
+            preset = 'default',
+          },
+          signature = {
+            enabled = true,
+          },
+          sources = {
+            default = {
+              'lsp',
+              'path',
+              'snippets',
+              'buffer',
+              'copilot',
+            },
+            providers = {
+              copilot = {
+                name = "copilot",
+                module = "blink-cmp-copilot",
+                score_offset = 100,
+                async = true,
+              },
+            },
+          },
+        })
+      '';
+    }
+  ];
+}

--- a/home/base/editor/neovim/plugins/default.nix
+++ b/home/base/editor/neovim/plugins/default.nix
@@ -1,0 +1,8 @@
+{
+  imports = [
+    ./ui.nix
+    ./completion.nix
+    ./lsp.nix
+    ./tools.nix
+  ];
+}

--- a/home/base/editor/neovim/plugins/lsp.nix
+++ b/home/base/editor/neovim/plugins/lsp.nix
@@ -1,0 +1,36 @@
+{pkgs, ...}: {
+  home.packages = with pkgs; [
+    gopls
+    nil
+    rust-analyzer
+    typescript-language-server
+  ];
+
+  programs.neovim.plugins = with pkgs.vimPlugins; [
+    {
+      plugin = nvim-lspconfig;
+      type = "lua";
+      config = ''
+        local servers = {"rust_analyzer", "gopls", "ts_ls", "nil_ls"};
+        local opt = {
+          on_attach = function(client, bufnr)
+            local opts = { noremap = true, silent = true }
+            vim.api.nvim_buf_set_keymap(bufnr, 'n', 'ca', '<cmd>lua vim.lsp.buf.code_action()<CR>', opts)
+            vim.api.nvim_buf_set_keymap(bufnr, 'n', 'gc', '<cmd>lua vim.lsp.buf.incoming_calls()<CR>', opts)
+            vim.api.nvim_buf_set_keymap(bufnr, 'n', 'go', '<cmd>lua vim.lsp.buf.outgoing_calls()<CR>', opts)
+            vim.api.nvim_buf_set_keymap(bufnr, 'n', 'gd', '<cmd>lua vim.lsp.buf.definition()<CR>', opts)
+            vim.api.nvim_buf_set_keymap(bufnr, 'n', 'gf', '<cmd>lua vim.lsp.buf.references()<CR>', opts)
+            vim.api.nvim_buf_set_keymap(bufnr, 'n', 'gi', '<cmd>lua vim.lsp.buf.implementation()<CR>', opts)
+            vim.api.nvim_buf_set_keymap(bufnr, 'n', 'gr', '<cmd>lua vim.lsp.buf.rename()<CR>', opts)
+            vim.cmd 'autocmd BufWritePre * lua vim.lsp.buf.format({ async = false, timeout_ms = 1000 })'
+          end,
+          capabilities = require('blink-cmp').get_lsp_capabilities()
+        }
+
+        for _, server in ipairs(servers) do
+          require('lspconfig')[server].setup(opt)
+        end
+      '';
+    }
+  ];
+}

--- a/home/base/editor/neovim/plugins/tools.nix
+++ b/home/base/editor/neovim/plugins/tools.nix
@@ -1,0 +1,20 @@
+{pkgs, ...}: {
+  programs.neovim.plugins = with pkgs.vimPlugins; [
+    {
+      plugin = telescope-nvim;
+      type = "lua";
+      config = ''
+        vim.keymap.set('n', '<Space><Space>', '<cmd>Telescope find_files<CR>', { noremap = true, silent = true })
+        vim.keymap.set('n', '<C-f>', '<cmd>Telescope live_grep<CR>', { noremap = true, silent = true })
+      '';
+    }
+    nvim-treesitter.withAllGrammars
+    {
+      plugin = gitlinker-nvim;
+      type = "lua";
+      config = ''
+        require("gitlinker").setup()
+      '';
+    }
+  ];
+}

--- a/home/base/editor/neovim/plugins/ui.nix
+++ b/home/base/editor/neovim/plugins/ui.nix
@@ -1,0 +1,45 @@
+{pkgs, ...}: {
+  programs.neovim.plugins = with pkgs.vimPlugins; [
+    {
+      plugin = iceberg-vim;
+      type = "viml";
+      config = ''
+        colorscheme iceberg
+      '';
+    }
+    {
+      plugin = which-key-nvim;
+      type = "lua";
+      config = ''
+        vim.keymap.set('n', '<leader>?', '<cmd>lua require("which-key").show({global = false})<CR>')
+      '';
+    }
+    {
+      plugin = incline-nvim;
+      type = "lua";
+      config = ''
+        require('incline').setup()
+      '';
+    }
+    {
+      plugin = nvim-notify;
+      type = "lua";
+      config = ''
+        require("notify").setup({
+          max_width = 50,
+          render = "wrapped-compact",
+          stages = "slide",
+          timeout = 1500,
+        })
+      '';
+    }
+    nui-nvim
+    {
+      plugin = noice-nvim;
+      type = "lua";
+      config = ''
+        require("noice").setup()
+      '';
+    }
+  ];
+}

--- a/home/base/shell/zsh/default.nix
+++ b/home/base/shell/zsh/default.nix
@@ -3,6 +3,10 @@
   pkgs,
   ...
 }: {
+  home.sessionPath = [
+    "$HOME/.local/bin"
+    "$HOME/.local/share/aquaproj-aqua/bin"
+  ];
   programs.zsh = {
     enable = true;
     dotDir = "${config.xdg.configHome}/zsh";
@@ -11,8 +15,6 @@
     autosuggestion.enable = true;
     syntaxHighlighting.enable = true;
     initContent = ''
-      export PATH="$HOME/.local/bin:$PATH"
-      export PATH="$HOME/.local/share/aquaproj-aqua/bin:$PATH"
       zstyle ':completion:*' matcher-list 'm:{a-z}={A-Z}'
       PROMPT="%F{white}%c%f
       %F{green}>%f "

--- a/home/base/terminal/tmux/default.nix
+++ b/home/base/terminal/tmux/default.nix
@@ -10,7 +10,6 @@
     terminal = "tmux-256color";
     shell = "${pkgs.zsh}/bin/zsh";
     extraConfig = ''
-      set -g default-command "${pkgs.zsh}/bin/zsh"
       set-option -ag terminal-overrides ',xterm-256color:RGB'
       # status line
       ## common


### PR DESCRIPTION
## Summary

- Neovim設定のextraConfig(VimL)をextraLuaConfig(Lua)に統一し、プラグイン定義を`plugins/`サブディレクトリに4カテゴリ(ui/completion/lsp/tools)で分割した
- `flake-utils`依存を削除し、`packages.aarch64-darwin.neovim`を直接定義するようにした
- zshのPATH管理を`export PATH=...`から`home.sessionPath`に移行し、tmuxの重複していた`default-command`設定を削除した

## Test plan

- [x] `alejandra --check .` でフォーマットを確認済み
- [x] `darwin-rebuild build --flake .#M4MacBookAir` でビルド成功を確認済み
- [x] `nix flake show` で `packages.aarch64-darwin.neovim` のみが出力されることを確認済み
- [x] `darwin-rebuild switch` で実際に適用して動作確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)