### PR TITLE
[codex] fix home-manager warning options

### DIFF
--- a/home/base/editor/neovim/default.nix
+++ b/home/base/editor/neovim/default.nix
@@ -7,7 +7,7 @@
     enable = true;
     defaultEditor = true;
     vimAlias = true;
-    extraLuaConfig = ''
+    initLua = ''
       -- options
       vim.opt.autoread = true
       vim.opt.background = "dark"

--- a/home/base/programs/git/default.nix
+++ b/home/base/programs/git/default.nix
@@ -4,13 +4,13 @@
   ...
 }: let
   _1passwordPath =
-    if pkgs.system == "aarch64-darwin"
+    if pkgs.stdenv.hostPlatform.system == "aarch64-darwin"
     then "/Applications/1Password.app/Contents/MacOS/op-ssh-sign"
     else "${pkgs._1password-gui}/bin/op-ssh-sign";
 in {
   programs.git = {
     enable = true;
-    extraConfig = {
+    settings = {
       core = {
         editor = "nvim";
       };

--- a/home/base/programs/ssh/default.nix
+++ b/home/base/programs/ssh/default.nix
@@ -1,13 +1,24 @@
 {pkgs, ...}: let
   _1passwordSockPath =
-    if pkgs.system == "aarch64-darwin"
+    if pkgs.stdenv.hostPlatform.system == "aarch64-darwin"
     then "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
     else "~/.1password/agent.sock";
 in {
   programs.ssh = {
     enable = true;
-    extraConfig = ''
-      IdentityAgent "${_1passwordSockPath}"
-    '';
+    enableDefaultConfig = false;
+    matchBlocks."*" = {
+      forwardAgent = false;
+      addKeysToAgent = "no";
+      compression = false;
+      serverAliveInterval = 0;
+      serverAliveCountMax = 3;
+      hashKnownHosts = false;
+      userKnownHostsFile = "~/.ssh/known_hosts";
+      controlMaster = "no";
+      controlPath = "~/.ssh/master-%r@%n:%p";
+      controlPersist = "no";
+      identityAgent = _1passwordSockPath;
+    };
   };
 }


### PR DESCRIPTION
## 概要
home-manager と nixpkgs 側のオプション名変更に追従していなかったため、`darwin-rebuild` 実行時に複数の警告が出ていました。今回の変更で、警告が出る設定キーを新しいキーへ移行し、将来削除予定の SSH 既定値についても明示設定へ切り替えました。

## ユーザー影響
この変更前はビルド自体は通るものの、毎回の再ビルド時に非推奨警告が表示され、設定の将来互換性に不安が残る状態でした。特に `programs.ssh` の既定値警告は、将来的な挙動変化を見落とすリスクがありました。

## 根本原因
Home Manager / nixpkgs の更新に伴い、以下の項目がリネームまたは非推奨化されていました。
- `programs.neovim.extraLuaConfig` -> `programs.neovim.initLua`
- `programs.git.extraConfig` -> `programs.git.settings`
- `pkgs.system` -> `pkgs.stdenv.hostPlatform.system`
- `programs.ssh` の暗黙既定値

既存設定が旧式のままだったため、評価時に警告が出ていました。

## 修正内容
- `home/base/editor/neovim/default.nix` で `extraLuaConfig` を `initLua` へ変更しました。
- `home/base/programs/git/default.nix` で `extraConfig` を `settings` へ変更しました。
- `home/base/programs/git/default.nix` と `home/base/programs/ssh/default.nix` で `pkgs.system` を `pkgs.stdenv.hostPlatform.system` へ変更しました。
- `home/base/programs/ssh/default.nix` で `enableDefaultConfig = false;` を設定し、これまでの既定相当値を `matchBlocks."*"` に明示しました。加えて `IdentityAgent` は `identityAgent` として同ブロックに移しました。

## 検証
- `alejandra .`
- `darwin-rebuild build --flake .#M4MacBookAir --no-write-lock-file`

上記でビルドは成功し、今回対象だった renamed/deprecation warning は再現しないことを確認しました。
