### PR TITLE
[codex] switch to nixfmt and refine nix/darwin defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ darwin-rebuild build --flake .#M4MacBookAir
 darwin-rebuild test --flake .#M4MacBookAir
 
 # Nix コードのフォーマット
-alejandra .
+nix fmt
 ```
 
 ## Architecture
@@ -43,7 +43,7 @@ alejandra .
 - 1Password が SSH agent と Git の GPG 署名を担っている
 - Docker ランタイムには colima を使用している
 - パッケージ一覧は `home/base/programs/default.nix` に集約している
-- Nix コードのフォーマットには alejandra を使用している
+- Nix コードのフォーマットには nixfmt を使用している
 
 ## Conventions
 

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     };
 
     nix-darwin = {
-      url = "github:LnL7/nix-darwin";
+      url = "github:nix-darwin/nix-darwin/master";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
@@ -38,6 +38,7 @@
         "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
       ];
     };
+    formatter.aarch64-darwin = nixpkgs.legacyPackages.aarch64-darwin.nixfmt-tree;
     packages.aarch64-darwin.neovim = inputs.neovim.packages.aarch64-darwin.default;
     darwinConfigurations = {
       M4MacBookAir = nix-darwin.lib.darwinSystem {

--- a/home/base/programs/default.nix
+++ b/home/base/programs/default.nix
@@ -8,12 +8,13 @@
   ];
   home = {
     packages = with pkgs; [
-      alejandra
+      nixfmt
       bat
       colima
       docker
       docker-buildx
       docker-compose
+      fd
       gh
       ghq
       htop
@@ -22,6 +23,8 @@
       lazygit
       mmv-go
       ni
+      nix-output-monitor
+      nix-tree
       ripgrep
       tree
     ];

--- a/home/base/programs/git/default.nix
+++ b/home/base/programs/git/default.nix
@@ -17,6 +17,13 @@ in {
       commit = {
         gpgsign = true;
       };
+      diff = {
+        colorMoved = "default";
+      };
+      fetch = {
+        prune = true;
+        pruneTags = true;
+      };
       ghq = {
         root = config.home.homeDirectory + "/ghq";
       };
@@ -29,8 +36,19 @@ in {
       init = {
         defaultBranch = "main";
       };
+      merge = {
+        conflictstyle = "zdiff3";
+      };
+      rebase = {
+        autosquash = true;
+        updateRefs = true;
+      };
+      rerere = {
+        enabled = true;
+      };
       push = {
         default = "current";
+        autoSetupRemote = true;
       };
       user = {
         name = "pranc1ngpegasus";
@@ -50,5 +68,15 @@ in {
       "go.work.sum"
       ".zettelkasten/"
     ];
+  };
+
+  programs.delta = {
+    enable = true;
+    enableGitIntegration = true;
+    options = {
+      navigate = true;
+      line-numbers = true;
+      side-by-side = false;
+    };
   };
 }

--- a/home/base/shell/zsh/default.nix
+++ b/home/base/shell/zsh/default.nix
@@ -14,6 +14,14 @@
     enableCompletion = true;
     autosuggestion.enable = true;
     syntaxHighlighting.enable = true;
+    history = {
+      size = 200000;
+      save = 200000;
+      ignoreAllDups = true;
+      expireDuplicatesFirst = true;
+      extended = true;
+      share = true;
+    };
     initContent = ''
       zstyle ':completion:*' matcher-list 'm:{a-z}={A-Z}'
       PROMPT="%F{white}%c%f

--- a/hosts/M4MacBookAir/default.nix
+++ b/hosts/M4MacBookAir/default.nix
@@ -3,6 +3,10 @@
     ../../modules/darwin
   ];
 
+  nixpkgs = {
+    hostPlatform = "aarch64-darwin";
+  };
+
   networking = {
     hostName = "M4MacBookAir";
   };

--- a/modules/darwin/system.nix
+++ b/modules/darwin/system.nix
@@ -26,10 +26,18 @@
       NSGlobalDomain = {
         "com.apple.trackpad.scaling" = 3.0;
         AppleInterfaceStyle = "Dark";
+        ApplePressAndHoldEnabled = false;
         AppleShowAllExtensions = true;
         InitialKeyRepeat = 15;
         KeyRepeat = 2;
+        NSAutomaticCapitalizationEnabled = false;
+        NSAutomaticDashSubstitutionEnabled = false;
+        NSAutomaticPeriodSubstitutionEnabled = false;
+        NSAutomaticQuoteSubstitutionEnabled = false;
+        NSAutomaticSpellingCorrectionEnabled = false;
         NSDisableAutomaticTermination = false;
+        NSNavPanelExpandedStateForSaveMode = true;
+        NSNavPanelExpandedStateForSaveMode2 = true;
         NSTextShowsControlCharacters = true;
       };
 
@@ -39,6 +47,8 @@
 
       dock = {
         autohide = true;
+        autohide-delay = 0.0;
+        autohide-time-modifier = 0.15;
         mru-spaces = false;
         minimize-to-application = true;
         show-process-indicators = true;
@@ -47,7 +57,12 @@
 
       finder = {
         AppleShowAllExtensions = true;
+        FXDefaultSearchScope = "SCcf";
         FXEnableExtensionChangeWarning = false;
+        FXPreferredViewStyle = "clmv";
+        ShowPathbar = true;
+        ShowStatusBar = true;
+        _FXSortFoldersFirst = true;
       };
 
       trackpad = {

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -2,7 +2,12 @@
   nix = {
     settings = {
       experimental-features = ["nix-command" "flakes"];
+      accept-flake-config = true;
       warn-dirty = false;
+      trusted-substituters = ["https://nix-community.cachix.org"];
+      trusted-public-keys = [
+        "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+      ];
       # ビルドログを保持しないことでストレージを節約する
       keep-build-log = false;
       # 空き容量が 1 GiB を下回るとビルド中でも GC が走り、5 GiB まで回収する


### PR DESCRIPTION
## 概要
このPRでは、Nixフォーマッタを `alejandra` から `nixfmt` に移行し、あわせてNix・Darwin・Home Managerの運用設定を見直しました。これにより、`nix fmt` を標準のフォーマットコマンドとして使える状態に統一しています。

## 背景と影響
従来は `alejandra` を前提にしていたため、flake標準のフォーマッタ実行との整合が取りにくい状態でした。今回 `formatter` を明示し、ドキュメントと導入パッケージを `nixfmt` に揃えることで、開発者が迷わず同じ手順でフォーマットできるようになります。

また、既存の作業ツリーに含まれていたNix/Darwin関連の設定改善も同一コミットに含めています。具体的にはGit運用補助設定、zsh履歴設定、Darwin defaults、Nix trusted substituter設定などです。

## 根本原因
フォーマッタに関する設定が
- 導入パッケージ
- 実行コマンド
- flakeの `formatter`
の3箇所で統一されていなかったことが原因です。

## 修正内容
- `home/base/programs/default.nix` で `alejandra` を `nixfmt` に置換
- `flake.nix` に `formatter.aarch64-darwin = nixpkgs.legacyPackages.aarch64-darwin.nixfmt-tree;` を追加
- `AGENTS.md` のフォーマット手順を `nix fmt` に更新
- あわせて既存のローカル変更として以下を含む
  - `modules/default.nix` のNix設定拡充
  - `modules/darwin/system.nix` のmacOS defaults拡充
  - `home/base/programs/git/default.nix` のGit/Delta設定追加
  - `home/base/shell/zsh/default.nix` の履歴設定追加
  - `hosts/M4MacBookAir/default.nix` の `hostPlatform` 明示

## 検証
- `darwin-rebuild build --flake .#M4MacBookAir` が成功することを確認しました。
