### PR TITLE
[codex] fix ssh identityagent path escaping

### DIFF
--- a/home/base/programs/ssh/default.nix
+++ b/home/base/programs/ssh/default.nix
@@ -1,7 +1,7 @@
 {pkgs, ...}: let
   _1passwordSockPath =
     if pkgs.stdenv.hostPlatform.system == "aarch64-darwin"
-    then "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+    then "~/Library/Group\\ Containers/2BUA8C4S2C.com.1password/t/agent.sock"
     else "~/.1password/agent.sock";
 in {
   programs.ssh = {


### PR DESCRIPTION
## 変更の背景
macOS で 1Password の SSH agent ソケットを `IdentityAgent` に指定している環境で、`~/.ssh/config` の読み込み時に `keyword identityagent extra arguments at end of line` が発生していました。その結果、SSH 設定の評価が中断され、`git@github.com` への接続が失敗していました。

## 原因
`home/base/programs/ssh/default.nix` で `IdentityAgent` に設定しているパスに `Group Containers` という空白を含むディレクトリ名があり、生成された SSH 設定で空白が区切りとして解釈されていました。

## 修正内容
`home/base/programs/ssh/default.nix` の Darwin 向け 1Password ソケットパスを `Group\\ Containers` に変更し、生成される `IdentityAgent` 行で空白がエスケープされるようにしました。

## ユーザー影響
この修正により、SSH 設定の構文エラーが解消され、1Password の SSH agent を使った GitHub への SSH 認証が正しく動作します。

## 検証
`darwin-rebuild build --flake .#M4MacBookAir` を実行してビルドが通ることを確認しました。
