### PR TITLE
[codex] manage flake lock and neovim stable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 result
-/flake.lock
+!flake.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ nix fmt
 - Nix モジュールを追加したら、対応する `default.nix` の imports にも追加する
 - ホスト固有の設定は `hosts/<hostname>/` に配置する
 - プラットフォーム共通の設定は `home/base/` に、プラットフォーム固有の設定は `home/darwin/` に配置する
-- `flake.lock` は `.gitignore` で除外されている
+- `flake.lock` は VCS で管理し、更新時は差分をコミットする
 
 ## Writing Rules
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,130 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "neovim",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769996383,
+        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770779995,
+        "narHash": "sha256-Evbc+u49wYQ5uyEi/HHxVFEt3g/w4MZxkMXMe7McjRM=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "b3f43db171474132528be57610bfa5fb3b766879",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "neovim": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "neovim-src": "neovim-src",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770768285,
+        "narHash": "sha256-VHslWcx9wSkWgGKnZwFa9TgsY7pmDBZ5mIdRAXLKViI=",
+        "owner": "nix-community",
+        "repo": "neovim-nightly-overlay",
+        "rev": "2934421063ec25f994956a892ce3603d73254b3d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "neovim-nightly-overlay",
+        "type": "github"
+      }
+    },
+    "neovim-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1770763009,
+        "narHash": "sha256-oJCLtEd9uRG9mLdH/QYrpeZyr4UhE0WXBrsxKd/lcVU=",
+        "owner": "neovim",
+        "repo": "neovim",
+        "rev": "1e9143879d6b05bf7e4ed2a59d64d18418d2594f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "neovim",
+        "repo": "neovim",
+        "type": "github"
+      }
+    },
+    "nix-darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770736414,
+        "narHash": "sha256-x5xdJgUxNflO9j2sJHIHnPujDy6eAWJPCMQml5y9XB4=",
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "rev": "7c952d9a524ffbbd5b5edca38fe6d943499585cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-darwin",
+        "ref": "master",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1770781623,
+        "narHash": "sha256-RYEMTlGCVc67pxVxjOlGd8w6fpF7Bur7gKL88FB0WTs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c05d2232d2feaa4c7a07f1168606917402868195",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "home-manager": "home-manager",
+        "neovim": "neovim",
+        "nix-darwin": "nix-darwin",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/home/base/editor/neovim/default.nix
+++ b/home/base/editor/neovim/default.nix
@@ -6,6 +6,7 @@
 
   programs.neovim = {
     enable = true;
+    package = pkgs.neovim-unwrapped;
     defaultEditor = true;
     vimAlias = true;
     initLua = ''

--- a/home/base/programs/git/default.nix
+++ b/home/base/programs/git/default.nix
@@ -65,8 +65,6 @@ in
       ".direnv"
       ".env"
       ".envrc"
-      "flake.lock"
-      "flake.nix"
       "go.work"
       "go.work.sum"
       ".zettelkasten/"


### PR DESCRIPTION
この変更は、Nix Flake の再現性と日常運用の整合性を改善するためのものです。これまでこのリポジトリでは `flake.lock` を管理対象から外していたため、同じコミットをチェックアウトしても評価時点によって取得される input の実体が変わり、利用者ごとに異なる結果になる可能性がありました。さらに、グローバル Git ignore 側でも `flake.nix` と `flake.lock` を無視していたため、意図せず差分が見えない状態が起きやすく、設定変更の追跡性が下がっていました。

根本原因は、再現性よりもローカル差分の回避を優先した ignore 設定が重なっていたことです。その結果として lock ファイルが VCS に乗らず、Flake 入力の固定点が失われていました。また Neovim については常用エディタである一方で、Home Manager 側で利用パッケージを明示していなかったため、将来の入力構成変更時に意図しないバージョンへ寄る余地が残っていました。

今回の修正では、`flake.lock` をリポジトリで管理する方針に合わせて `.gitignore` を更新し、あわせて AGENTS ドキュメント内の運用記述も現行方針へ更新しました。加えて、`programs.git.ignores` から `flake.nix` と `flake.lock` を削除し、リポジトリごとの管理が正しく機能する状態に戻しました。Neovim については Home Manager 設定で `pkgs.neovim-unwrapped` を明示して、常用エディタとして安定版を利用する意図を設定として固定しています。

検証として `nix flake check --no-build path:.` を実行し、評価が通ることを確認しました。既存の `unknown flake output 'nixConfig'` 警告は今回の変更範囲外であり、挙動は従来どおりです。また `nix eval` で Home Manager が参照する Neovim バージョンを確認し、`0.11.6` であることを確認しました。
