### PR TITLE
[codex] Optimize nix storage settings and tooling footprint

### DIFF
--- a/home/base/editor/neovim/default.nix
+++ b/home/base/editor/neovim/default.nix
@@ -7,6 +7,8 @@
   programs.neovim = {
     enable = true;
     package = pkgs.neovim-unwrapped;
+    withPython3 = false;
+    withRuby = false;
     defaultEditor = true;
     vimAlias = true;
     initLua = ''

--- a/home/base/programs/git/default.nix
+++ b/home/base/programs/git/default.nix
@@ -13,6 +13,7 @@ in
 {
   programs.git = {
     enable = true;
+    package = pkgs.gitMinimal;
     settings = {
       core = {
         editor = "nvim";

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -14,6 +14,9 @@
       ];
       # ビルドログを保持しないことでストレージを節約する
       keep-build-log = false;
+      # 不要な参照を保持しないようにしてストレージ使用量を抑える
+      keep-derivations = false;
+      keep-outputs = false;
       # 空き容量が 1 GiB を下回るとビルド中でも GC が走り、5 GiB まで回収する
       min-free = 1073741824; # 1 GiB
       max-free = 5368709120; # 5 GiB
@@ -26,7 +29,7 @@
         Hour = 2;
         Minute = 0;
       };
-      options = "--delete-older-than 30d";
+      options = "--delete-older-than 14d";
     };
 
     optimise = {


### PR DESCRIPTION
## 背景
このリポジトリでは Home Manager と nix-darwin で開発ツールを一括管理していますが、いくつかの設定が不要な runtime を含んだままになっており、/nix/store の増加要因になっていました。特に Neovim provider と Git パッケージ選択、GC 保持期間の設定には見直し余地がありました。

## 問題の影響
Neovim の Python/Ruby provider が有効だと依存 closure が広がり、システム再構築や世代保持時のストレージ使用量が増えます。Git もフル版を使う必要がないケースでは最小版を選ぶほうが容量効率が良くなります。GC 保持期間が長いと、切り替え頻度が高い運用で古い世代が残りやすくなります。

## 根本原因
初期設定時に安全側で provider とフル機能パッケージを有効にしていたため、現在の実運用に対して設定が過剰になっていました。加えて GC の保持期間が容量優先の値になっていませんでした。

## 変更内容
- `home/base/editor/neovim/default.nix` で `programs.neovim.withPython3 = false` と `withRuby = false` を設定し、不要 provider を無効化しました。
- `home/base/programs/git/default.nix` で `programs.git.package = pkgs.gitMinimal` を指定しました。
- `modules/default.nix` で `nix.settings.keep-derivations = false` と `keep-outputs = false` を設定し、`nix.gc.options` を `--delete-older-than 14d` に変更しました。

## 検証
- `nix fmt`
- `nix eval .#darwinConfigurations.M4MacBookAir.config.home-manager.users.pranc1ngpegasus.programs.neovim.withPython3` が `false`
- `nix eval .#darwinConfigurations.M4MacBookAir.config.home-manager.users.pranc1ngpegasus.programs.neovim.withRuby` が `false`
- `nix eval .#darwinConfigurations.M4MacBookAir.config.home-manager.users.pranc1ngpegasus.programs.git.package.name` が `"git-minimal-2.52.0"`
- `nix eval .#darwinConfigurations.M4MacBookAir.config.nix.settings.keep-derivations` が `false`
- `nix eval .#darwinConfigurations.M4MacBookAir.config.nix.settings.keep-outputs` が `false`
- `nix eval .#darwinConfigurations.M4MacBookAir.config.nix.gc.options` が `"--delete-older-than 14d"`
- `nix build --dry-run .#darwinConfigurations.M4MacBookAir.config.system.build.toplevel`

## 補足
`nix.settings.auto-optimise-store` は nix-darwin 側のアサーションで禁止されるため、この PR では設定していません。既存の `nix.optimise.automatic = true` を維持しています。
