### PR TITLE
[codex] fix flake nixConfig placement

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,15 @@
     };
   };
 
+  nixConfig = {
+    extra-substituters = [
+      "https://nix-community.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+    ];
+  };
+
   outputs =
     {
       self,
@@ -33,14 +42,6 @@
       inherit (self) outputs;
     in
     {
-      nixConfig = {
-        extra-substituters = [
-          "https://nix-community.cachix.org"
-        ];
-        extra-trusted-public-keys = [
-          "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-        ];
-      };
       formatter.aarch64-darwin = nixpkgs.legacyPackages.aarch64-darwin.nixfmt-tree;
       packages.aarch64-darwin.neovim = inputs.neovim.packages.aarch64-darwin.default;
       darwinConfigurations = {


### PR DESCRIPTION
## What happened
Running `nix flake check --no-build` emitted `warning: unknown flake output 'nixConfig'`. This warning indicates that `nixConfig` was placed in the wrong part of the flake schema.

## User impact
The warning adds noise to routine validation and makes it harder to spot real evaluation issues. It also means the intended flake-level Nix client settings are not being declared in the canonical location.

## Root cause
`nixConfig` was defined inside `outputs`, where Nix interprets attributes as flake outputs. Because `nixConfig` is a top-level flake attribute, Nix treated it as an unknown output and emitted the warning.

## Fix
Moved `nixConfig` from inside `outputs` to the top level of `flake.nix`, immediately alongside `inputs` and `outputs`. No setting values were changed.

## Validation
I ran:

- `nix flake check --no-build`

After the change, the `unknown flake output 'nixConfig'` warning no longer appears. The remaining warning about `trusted-public-keys` is an environment trust restriction and is unrelated to flake schema correctness.
