### PR TITLE
[codex] remove global aqua dependency

### DIFF
--- a/home/base/shell/zsh/default.nix
+++ b/home/base/shell/zsh/default.nix
@@ -6,7 +6,6 @@
 {
   home.sessionPath = [
     "$HOME/.local/bin"
-    "$HOME/.local/share/aquaproj-aqua/bin"
   ];
   programs.zsh = {
     enable = true;


### PR DESCRIPTION
## 変更の背景
これまで zsh の `PATH` に `$HOME/.local/share/aquaproj-aqua/bin` を常時追加していたため、`aqua` をグローバルに配置している前提が設定に埋め込まれていました。この状態では、`aqua` の運用方針をローカル利用へ寄せた場合でもシェル初期化で不要なパスが残り続けます。

## 影響と根本原因
ユーザー環境が `aqua` のグローバル配置に依存しない構成であっても、zsh 設定が旧前提のままになっていました。根本原因は、`home.sessionPath` に `aqua` の固定パスを直接記述していたことです。

## 対応内容
`home/base/shell/zsh/default.nix` の `home.sessionPath` から `$HOME/.local/share/aquaproj-aqua/bin` を削除しました。これにより、グローバルな `aqua` 配置がなくても zsh の `PATH` が不要に汚染されない状態になります。

## 検証
変更後に `nix fmt` を実行してフォーマットを確認し、さらに `darwin-rebuild build --flake .#M4MacBookAir` を実行してビルドが成功することを確認しました。
