### PR TITLE
[codex] pin zsh plugin revs to commit sha

### DIFF
--- a/home/base/shell/zsh/default.nix
+++ b/home/base/shell/zsh/default.nix
@@ -34,7 +34,7 @@
         src = pkgs.fetchFromGitHub {
           owner = "pranc1ngpegasus";
           repo = "zsh-ghq-skim";
-          rev = "main";
+          rev = "5d030e7aef94eb1804a0f216a801c47bd357d2a4";
           sha256 = "sha256-U/b7zdP5y1k5kADNy7hf7BYr9H7AZsL6arW1qOozdxk=";
         };
       }
@@ -43,7 +43,7 @@
         src = pkgs.fetchFromGitHub {
           owner = "pranc1ngpegasus";
           repo = "zsh-gwt-skim";
-          rev = "main";
+          rev = "1cb2450bfa74e31194503805d9cec22711aa7fa4";
           sha256 = "sha256-gVdDnvEUG3JiuDDVWrDeOBlmF+C7KbQwNiIVDukT+xY=";
         };
       }


### PR DESCRIPTION
## What issue this solves
The zsh plugin sources for `zsh-ghq-skim` and `zsh-gwt-skim` were pinned to `rev = "main"`. This makes evaluation depend on whatever commit happens to be at the branch tip at build time.

## User impact and behavior
With `main` tracking, a rebuild can start failing or change behavior without any local code changes because upstream moved. The existing `sha256` values also require manual updates after upstream branch movement, so breakage can appear unexpectedly.

## Root cause
`fetchFromGitHub` is being used with a floating ref (`main`) instead of an immutable revision. In declarative Nix configuration, floating refs reduce reproducibility and make diffs less auditable.

## Fix
This PR replaces both floating `rev` values with concrete commit SHAs:
- `zsh-ghq-skim`: `5d030e7aef94eb1804a0f216a801c47bd357d2a4`
- `zsh-gwt-skim`: `1cb2450bfa74e31194503805d9cec22711aa7fa4`

The existing `sha256` values remain unchanged because they already match those exact commit tarballs.

## Validation
I validated the change with:
- `nix fmt`
- `nix eval --json .#darwinConfigurations.M4MacBookAir.config.home-manager.users.pranc1ngpegasus.programs.zsh.plugins >/dev/null`
- `git diff --stat` confirms only `home/base/shell/zsh/default.nix` changed
