### PR TITLE
[codex] Improve nvim startup and remove mise global install

### DIFF
--- a/home/base/editor/neovim/default.nix
+++ b/home/base/editor/neovim/default.nix
@@ -12,6 +12,10 @@
     defaultEditor = true;
     vimAlias = true;
     initLua = ''
+      pcall(function()
+        vim.loader.enable()
+      end)
+
       -- options
       vim.opt.autoread = true
       vim.opt.background = "dark"

--- a/home/base/editor/neovim/plugins/completion.nix
+++ b/home/base/editor/neovim/plugins/completion.nix
@@ -1,17 +1,28 @@
 { pkgs, ... }:
 {
+  home.packages = with pkgs; [
+    nodejs
+  ];
+
   programs.neovim.plugins = with pkgs.vimPlugins; [
     {
       plugin = copilot-lua;
       type = "lua";
       config = ''
-        require("copilot").setup({
-          suggestion = {
-            enabled = false,
-          },
-          panel = {
-            enabled = false,
-          },
+        local copilot_group = vim.api.nvim_create_augroup("copilot_lazy_setup", { clear = true })
+        vim.api.nvim_create_autocmd("InsertEnter", {
+          group = copilot_group,
+          once = true,
+          callback = function()
+            require("copilot").setup({
+              suggestion = {
+                enabled = false,
+              },
+              panel = {
+                enabled = false,
+              },
+            })
+          end,
         })
       '';
     }
@@ -20,56 +31,63 @@
       plugin = blink-cmp;
       type = "lua";
       config = ''
-        require('blink-cmp').setup({
-          completion = {
-            accept = {
-              auto_brackets = {
+        local blink_group = vim.api.nvim_create_augroup("blink_cmp_lazy_setup", { clear = true })
+        vim.api.nvim_create_autocmd("InsertEnter", {
+          group = blink_group,
+          once = true,
+          callback = function()
+            require('blink-cmp').setup({
+              completion = {
+                accept = {
+                  auto_brackets = {
+                    enabled = true,
+                  },
+                },
+                documentation = {
+                  auto_show = true,
+                  auto_show_delay_ms = 500,
+                },
+                keyword = {
+                  range = 'full',
+                },
+                list = {
+                  selection = {
+                    preselect = false,
+                    auto_insert = true,
+                  },
+                },
+                menu = {
+                  auto_show = true,
+                },
+                ghost_text = {
+                  enabled = true,
+                },
+              },
+              keymap = {
+                preset = 'default',
+              },
+              signature = {
                 enabled = true,
               },
-            },
-            documentation = {
-              auto_show = true,
-              auto_show_delay_ms = 500,
-            },
-            keyword = {
-              range = 'full',
-            },
-            list = {
-              selection = {
-                preselect = false,
-                auto_insert = true,
+              sources = {
+                default = {
+                  'lsp',
+                  'path',
+                  'snippets',
+                  'buffer',
+                  'copilot',
+                },
+                providers = {
+                  copilot = {
+                    name = "copilot",
+                    module = "blink-cmp-copilot",
+                    score_offset = 100,
+                    async = true,
+                  },
+                },
               },
-            },
-            menu = {
-              auto_show = true,
-            },
-            ghost_text = {
-              enabled = true,
-            },
-          },
-          keymap = {
-            preset = 'default',
-          },
-          signature = {
-            enabled = true,
-          },
-          sources = {
-            default = {
-              'lsp',
-              'path',
-              'snippets',
-              'buffer',
-              'copilot',
-            },
-            providers = {
-              copilot = {
-                name = "copilot",
-                module = "blink-cmp-copilot",
-                score_offset = 100,
-                async = true,
-              },
-            },
-          },
+            })
+          end,
         })
       '';
     }

--- a/home/base/editor/neovim/plugins/lsp.nix
+++ b/home/base/editor/neovim/plugins/lsp.nix
@@ -12,25 +12,49 @@
       plugin = nvim-lspconfig;
       type = "lua";
       config = ''
-        local servers = {"rust_analyzer", "gopls", "ts_ls", "nil_ls"};
-        local opt = {
-          on_attach = function(client, bufnr)
-            local opts = { noremap = true, silent = true }
-            vim.api.nvim_buf_set_keymap(bufnr, 'n', 'ca', '<cmd>lua vim.lsp.buf.code_action()<CR>', opts)
-            vim.api.nvim_buf_set_keymap(bufnr, 'n', 'gc', '<cmd>lua vim.lsp.buf.incoming_calls()<CR>', opts)
-            vim.api.nvim_buf_set_keymap(bufnr, 'n', 'go', '<cmd>lua vim.lsp.buf.outgoing_calls()<CR>', opts)
-            vim.api.nvim_buf_set_keymap(bufnr, 'n', 'gd', '<cmd>lua vim.lsp.buf.definition()<CR>', opts)
-            vim.api.nvim_buf_set_keymap(bufnr, 'n', 'gf', '<cmd>lua vim.lsp.buf.references()<CR>', opts)
-            vim.api.nvim_buf_set_keymap(bufnr, 'n', 'gi', '<cmd>lua vim.lsp.buf.implementation()<CR>', opts)
-            vim.api.nvim_buf_set_keymap(bufnr, 'n', 'gr', '<cmd>lua vim.lsp.buf.rename()<CR>', opts)
-            vim.cmd 'autocmd BufWritePre * lua vim.lsp.buf.format({ async = false, timeout_ms = 1000 })'
-          end,
-          capabilities = require('blink-cmp').get_lsp_capabilities()
-        }
+        local servers = {"rust_analyzer", "gopls", "ts_ls", "nil_ls"}
 
-        for _, server in ipairs(servers) do
-          require('lspconfig')[server].setup(opt)
-        end
+        local lsp_setup_group = vim.api.nvim_create_augroup("user_lsp_lazy_setup", { clear = true })
+        vim.api.nvim_create_autocmd({"BufReadPre", "BufNewFile"}, {
+          group = lsp_setup_group,
+          once = true,
+          callback = function()
+            local capabilities = vim.lsp.protocol.make_client_capabilities()
+            local blink_ok, blink = pcall(require, "blink-cmp")
+            if blink_ok then
+              capabilities = blink.get_lsp_capabilities(capabilities)
+            end
+
+            local format_group = vim.api.nvim_create_augroup("user_lsp_format_on_save", { clear = false })
+            local opt = {
+              on_attach = function(_, bufnr)
+                local opts = { noremap = true, silent = true, buffer = bufnr }
+                vim.keymap.set("n", "ca", vim.lsp.buf.code_action, opts)
+                vim.keymap.set("n", "gc", vim.lsp.buf.incoming_calls, opts)
+                vim.keymap.set("n", "go", vim.lsp.buf.outgoing_calls, opts)
+                vim.keymap.set("n", "gd", vim.lsp.buf.definition, opts)
+                vim.keymap.set("n", "gf", vim.lsp.buf.references, opts)
+                vim.keymap.set("n", "gi", vim.lsp.buf.implementation, opts)
+                vim.keymap.set("n", "gr", vim.lsp.buf.rename, opts)
+
+                vim.api.nvim_clear_autocmds({ group = format_group, buffer = bufnr })
+                vim.api.nvim_create_autocmd("BufWritePre", {
+                  group = format_group,
+                  buffer = bufnr,
+                  callback = function()
+                    vim.lsp.buf.format({ async = false, timeout_ms = 1000 })
+                  end,
+                })
+              end,
+              capabilities = capabilities,
+            }
+
+            local lspconfig = require("lspconfig")
+            for _, server in ipairs(servers) do
+              lspconfig[server].setup(opt)
+            end
+          end,
+        })
       '';
     }
   ];

--- a/home/base/editor/neovim/plugins/tools.nix
+++ b/home/base/editor/neovim/plugins/tools.nix
@@ -14,7 +14,14 @@
       plugin = gitlinker-nvim;
       type = "lua";
       config = ''
-        require("gitlinker").setup()
+        local gitlinker_group = vim.api.nvim_create_augroup("gitlinker_lazy_setup", { clear = true })
+        vim.api.nvim_create_autocmd({"BufReadPost", "BufNewFile"}, {
+          group = gitlinker_group,
+          once = true,
+          callback = function()
+            require("gitlinker").setup()
+          end,
+        })
       '';
     }
   ];

--- a/home/base/editor/neovim/plugins/ui.nix
+++ b/home/base/editor/neovim/plugins/ui.nix
@@ -19,7 +19,16 @@
       plugin = incline-nvim;
       type = "lua";
       config = ''
-        require('incline').setup()
+        local incline_group = vim.api.nvim_create_augroup("incline_lazy_setup", { clear = true })
+        vim.api.nvim_create_autocmd("UIEnter", {
+          group = incline_group,
+          once = true,
+          callback = function()
+            vim.defer_fn(function()
+              require('incline').setup()
+            end, 10)
+          end,
+        })
       '';
     }
     {
@@ -39,7 +48,16 @@
       plugin = noice-nvim;
       type = "lua";
       config = ''
-        require("noice").setup()
+        local noice_group = vim.api.nvim_create_augroup("noice_lazy_setup", { clear = true })
+        vim.api.nvim_create_autocmd("UIEnter", {
+          group = noice_group,
+          once = true,
+          callback = function()
+            vim.defer_fn(function()
+              require("noice").setup()
+            end, 10)
+          end,
+        })
       '';
     }
   ];

--- a/home/base/programs/default.nix
+++ b/home/base/programs/default.nix
@@ -3,7 +3,6 @@
   imports = [
     ./direnv
     ./git
-    ./mise
     ./skim
     ./ssh
   ];

--- a/home/base/programs/mise/default.nix
+++ b/home/base/programs/mise/default.nix
@@ -1,7 +1,0 @@
-{ ... }:
-{
-  programs.mise = {
-    enable = true;
-    enableZshIntegration = true;
-  };
-}


### PR DESCRIPTION
## 背景
Neovim の起動ログを見ると、初期化の早い段階で `copilot`、`blink-cmp`、`lspconfig`、`gitlinker`、`noice`、`incline` が読み込まれていました。日常的な起動のたびに不要な初期化コストが先払いされるため、操作開始までの体感が遅くなる状態でした。

同時に、Copilot の実行に必要な `node` が Nix 管理外のグローバル `mise` に依存していました。この構成だとマシン再構築時に Neovim 側が壊れやすく、再現性も落ちます。

## 影響
今回の変更前は `startuptime` ログ上で最終 `--- NVIM STARTED ---` が 68.498ms でした。変更後は同条件の計測で 32.279ms になり、初期化時間が短縮されています。

また `init.lua` 相当の読み込み時間は 44.129ms から 4.902ms に下がっています。重いプラグインの初期化を必要時まで遅らせたことが主因です。

## 根本原因
起動直後に必ず必要ではないプラグインまで即時 `require` していたことと、Copilot のランタイム依存がシステム外の `mise` に置かれていたことが原因でした。

## 対応内容
- Neovim 設定で `vim.loader.enable()` を有効化しました。
- `copilot` と `blink-cmp` は `InsertEnter` の初回時に遅延初期化するように変更しました。
- LSP セットアップは `BufReadPre` / `BufNewFile` の初回時に行うように変更しました。
- `gitlinker` は `BufReadPost` / `BufNewFile` の初回時に初期化するように変更しました。
- `incline` と `noice` は `UIEnter` 後に遅延初期化するように変更しました。
- Copilot 依存として `nodejs` を `home.packages` に追加しました。
- グローバル `mise` 利用をやめるため、`home/base/programs/default.nix` から `./mise` の import を削除し、未使用になった `home/base/programs/mise/default.nix` を削除しました。

## 検証
- `nix fmt`
- `darwin-rebuild build --flake .#M4MacBookAir`
- `nvim --startuptime /tmp/startup-new-ui.log -u <generated hm_nviminit.lua> +qa`
- 既存ログ `/tmp/startup.log` と新規ログ `/tmp/startup-new-ui.log` の比較
