### PR TITLE
[codex] prune unused packages and remove neovim copilot

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,8 +35,8 @@ nix-darwin のシステムレベル設定をまとめている。`modules/defaul
 
 全プラットフォーム共通のユーザー環境設定を置く場所で、以下のサブモジュールを持つ。
 
-- `editor/neovim/` は Neovim nightly に LSP (gopls, nil, rust-analyzer, typescript-language-server) と Copilot、各種プラグインを組み合わせた設定を管理している。プラグイン定義は `plugins/` サブディレクトリに分割されており、ui, completion, lsp, tools の 4 カテゴリで構成されている
-- `programs/` はパッケージ一覧 (`default.nix`) と、git, direnv, mise, skim, ssh といった個別ツールの設定を管理している
+- `editor/neovim/` は Neovim nightly に LSP (gopls, nil, rust-analyzer, typescript-language-server) と各種プラグインを組み合わせた設定を管理している。プラグイン定義は `plugins/` サブディレクトリに分割されており、ui, completion, lsp, tools の 4 カテゴリで構成されている
+- `programs/` はパッケージ一覧 (`default.nix`) と、git, direnv, skim, ssh といった個別ツールの設定を管理している
 - `shell/zsh/` は Zsh の設定と ghq-skim, gwt-skim プラグインを管理している
 - `terminal/tmux/` は Tmux の設定を管理している (prefix は C-q)
 

--- a/home/base/editor/neovim/plugins/completion.nix
+++ b/home/base/editor/neovim/plugins/completion.nix
@@ -1,32 +1,6 @@
 { pkgs, ... }:
 {
-  home.packages = with pkgs; [
-    nodejs
-  ];
-
   programs.neovim.plugins = with pkgs.vimPlugins; [
-    {
-      plugin = copilot-lua;
-      type = "lua";
-      config = ''
-        local copilot_group = vim.api.nvim_create_augroup("copilot_lazy_setup", { clear = true })
-        vim.api.nvim_create_autocmd("InsertEnter", {
-          group = copilot_group,
-          once = true,
-          callback = function()
-            require("copilot").setup({
-              suggestion = {
-                enabled = false,
-              },
-              panel = {
-                enabled = false,
-              },
-            })
-          end,
-        })
-      '';
-    }
-    blink-cmp-copilot
     {
       plugin = blink-cmp;
       type = "lua";
@@ -75,15 +49,6 @@
                   'path',
                   'snippets',
                   'buffer',
-                  'copilot',
-                },
-                providers = {
-                  copilot = {
-                    name = "copilot",
-                    module = "blink-cmp-copilot",
-                    score_offset = 100,
-                    async = true,
-                  },
                 },
               },
             })

--- a/home/base/programs/default.nix
+++ b/home/base/programs/default.nix
@@ -8,25 +8,17 @@
   ];
   home = {
     packages = with pkgs; [
-      nixfmt
-      bat
       colima
       docker
       docker-buildx
       docker-compose
-      fd
       gh
       ghq
-      htop
       httpie
       jq
       lazygit
       mmv-go
-      ni
-      nix-output-monitor
-      nix-tree
       ripgrep
-      tree
     ];
   };
 }


### PR DESCRIPTION
## Overview
This change trims packages that are currently unused and removes Neovim Copilot integration, while keeping `colima` in place as requested.

Users benefit from a leaner environment definition with fewer installed tools and fewer transitive dependencies in Home Manager generations.

## Problem
The package list in `home/base/programs/default.nix` had accumulated tools that are no longer used. In addition, Neovim completion still included Copilot integration, which required `nodejs` in Home Manager.

This increased closure size and maintenance surface, and kept AI completion behavior enabled in Neovim despite the current preference to reduce that dependency.

## Root Cause
The configuration had not been recently pruned against current usage patterns, and historical Copilot setup remained in `home/base/editor/neovim/plugins/completion.nix`.

## Fix
- Removed these packages from `home/base/programs/default.nix`:
  - `nixfmt`
  - `bat`
  - `fd`
  - `htop`
  - `ni`
  - `nix-output-monitor`
  - `nix-tree`
  - `tree`
- Kept `colima` as requested.
- Removed Neovim Copilot integration from `home/base/editor/neovim/plugins/completion.nix`:
  - removed `home.packages = [ nodejs ]`
  - removed `copilot-lua`
  - removed `blink-cmp-copilot`
  - removed `copilot` source/provider wiring from `blink-cmp`.
- Updated architecture documentation to match the current setup:
  - removed Copilot mention
  - removed stale `mise` mention from `programs/` description.

## Validation
- Ran `nix fmt`.
- Ran `darwin-rebuild build --flake .#M4MacBookAir` successfully.
- Confirmed removed package names do not appear in evaluated `home.packages` for `M4MacBookAir`.

## Impact
- Reduced installed user-facing package set.
- Reduced dependency footprint by dropping Node.js that was only present for Neovim Copilot integration.
- No system-level behavior changes outside of package/tool availability and Neovim Copilot completion removal.
