### PR TITLE
[codex] update zsh plugins

### DIFF
--- a/home/base/shell/zsh/default.nix
+++ b/home/base/shell/zsh/default.nix
@@ -33,8 +33,8 @@
         src = pkgs.fetchFromGitHub {
           owner = "pranc1ngpegasus";
           repo = "zsh-ghq-skim";
-          rev = "5d030e7aef94eb1804a0f216a801c47bd357d2a4";
-          sha256 = "sha256-U/b7zdP5y1k5kADNy7hf7BYr9H7AZsL6arW1qOozdxk=";
+          rev = "a40d2a03c7b99c3bd39d69539a0932b3d6f12373";
+          sha256 = "sha256-dJNQzT5fYTAoG2odRyiEpjC2TIhN1scTHcH0N20YAVg=";
         };
       }
       {
@@ -42,8 +42,8 @@
         src = pkgs.fetchFromGitHub {
           owner = "pranc1ngpegasus";
           repo = "zsh-gwt-skim";
-          rev = "1cb2450bfa74e31194503805d9cec22711aa7fa4";
-          sha256 = "sha256-gVdDnvEUG3JiuDDVWrDeOBlmF+C7KbQwNiIVDukT+xY=";
+          rev = "cfc1663e40fc56b428d5567043ebccd29a861b58";
+          sha256 = "sha256-JqvdDNHV3/9ftCS+Occx2qtUX008TtVMLk4zdXcyL/w=";
         };
       }
     ];


### PR DESCRIPTION
## Summary
This PR updates two custom zsh plugins to their latest upstream commits so the local shell environment tracks current behavior and fixes.

## Issue and user impact
The dotfiles configuration pinned `zsh-ghq-skim` and `zsh-gwt-skim` to older revisions. When those pins lag behind upstream, users can miss bug fixes and behavior improvements, and new shell setup ends up inconsistent with the latest plugin state.

## Root cause
Both plugins are sourced via `fetchFromGitHub` with fixed `rev` and `sha256`, so they do not update automatically unless these values are manually bumped.

## Fix
I updated the pinned revisions and hashes in `home/base/shell/zsh/default.nix`:

- `zsh-ghq-skim`: `5d030e7...` -> `a40d2a0...`
- `zsh-gwt-skim`: `1cb2450...` -> `cfc1663...`

The corresponding `sha256` values were recomputed with `nix store prefetch-file --json --unpack`.

## Validation
I validated the configuration with:

- `nix fmt`
- `darwin-rebuild build --flake .#M4MacBookAir`

Both commands completed successfully.
