### PR TITLE
[codex] update zsh skim plugin revisions

### DIFF
--- a/home/base/editor/neovim/plugins/lsp.nix
+++ b/home/base/editor/neovim/plugins/lsp.nix
@@ -49,9 +49,9 @@
               capabilities = capabilities,
             }
 
-            local lspconfig = require("lspconfig")
             for _, server in ipairs(servers) do
-              lspconfig[server].setup(opt)
+              vim.lsp.config(server, opt)
+              vim.lsp.enable(server)
             end
           end,
         })

--- a/home/base/editor/neovim/plugins/lsp.nix
+++ b/home/base/editor/neovim/plugins/lsp.nix
@@ -49,9 +49,9 @@
               capabilities = capabilities,
             }
 
+            local lspconfig = require("lspconfig")
             for _, server in ipairs(servers) do
-              vim.lsp.config(server, opt)
-              vim.lsp.enable(server)
+              lspconfig[server].setup(opt)
             end
           end,
         })

--- a/home/base/shell/zsh/default.nix
+++ b/home/base/shell/zsh/default.nix
@@ -33,8 +33,8 @@
         src = pkgs.fetchFromGitHub {
           owner = "pranc1ngpegasus";
           repo = "zsh-ghq-skim";
-          rev = "a40d2a03c7b99c3bd39d69539a0932b3d6f12373";
-          sha256 = "sha256-dJNQzT5fYTAoG2odRyiEpjC2TIhN1scTHcH0N20YAVg=";
+          rev = "186b672b4cb02e9c3ded29984a890bddd11929ae";
+          sha256 = "sha256-Ci6apbmtG6biigbOzBMU9YgTC7LLi+Um88/sHKarF40=";
         };
       }
       {
@@ -42,8 +42,8 @@
         src = pkgs.fetchFromGitHub {
           owner = "pranc1ngpegasus";
           repo = "zsh-gwt-skim";
-          rev = "cfc1663e40fc56b428d5567043ebccd29a861b58";
-          sha256 = "sha256-JqvdDNHV3/9ftCS+Occx2qtUX008TtVMLk4zdXcyL/w=";
+          rev = "14af013c875dff94c3fdc3089e808a8785248625";
+          sha256 = "sha256-2Pf1NzgA8wW78hGDt2mzwAS1h8tdWUyt04hgvsiwvso=";
         };
       }
     ];


### PR DESCRIPTION
## 概要
zsh の skim 関連プラグイン参照を更新し、`zsh-ghq-skim` と `zsh-gwt-skim` の最新版を取り込みました。

この変更は、`sk-tmux` から `sk --tmux` への移行に関する修正を dotfiles 側へ反映するためのものです。

## 背景
最近の skim 側変更により、`sk-tmux` は非推奨になり `sk --tmux` が推奨される運用へ移行しています。
その影響で、zsh プラグイン側の呼び出し方法を更新した最新版を取り込む必要がありました。

## ユーザー影響
今回の更新により、`Ctrl-g`（ghq）および `Ctrl-w`（git worktree）で起動する skim UI が、最新プラグイン実装に追従します。
これにより、tmux popup を前提とした動作とオプション適用の整合性が改善されます。

## 変更内容
- `home/base/shell/zsh/default.nix`
  - `zsh-ghq-skim`
    - `rev` を `a40d2a03c7b99c3bd39d69539a0932b3d6f12373` から `186b672b4cb02e9c3ded29984a890bddd11929ae` に更新
    - `sha256` を対応値に更新
  - `zsh-gwt-skim`
    - `rev` を `cfc1663e40fc56b428d5567043ebccd29a861b58` から `14af013c875dff94c3fdc3089e808a8785248625` に更新
    - `sha256` を対応値に更新

## 検証
- `nix flake check --no-build` を実行して評価が通ることを確認しました。

## 補足
作業中に混入した `home/base/editor/neovim/plugins/lsp.nix` の変更は、別コミットで打ち消しており、最終的な PR 差分には含まれていません。
