### PR TITLE
[codex] migrate neovim lsp setup to vim.lsp.config

### DIFF
--- a/home/base/editor/neovim/plugins/lsp.nix
+++ b/home/base/editor/neovim/plugins/lsp.nix
@@ -49,9 +49,9 @@
               capabilities = capabilities,
             }
 
-            local lspconfig = require("lspconfig")
             for _, server in ipairs(servers) do
-              lspconfig[server].setup(opt)
+              vim.lsp.config(server, opt)
+              vim.lsp.enable(server)
             end
           end,
         })


### PR DESCRIPTION
## 概要
Neovim 起動時に `nvim-lspconfig` の非推奨警告が表示される問題を解消します。表示されていた警告は `require("lspconfig")` フレームワークの廃止予告に関するもので、将来の `nvim-lspconfig v3.0.0` で削除される API に依存していたことが原因です。

## ユーザー影響
この警告が毎回表示されると起動時の体験が悪化し、将来のプラグイン更新で LSP 初期化が壊れるリスクがありました。特に `init.lua` の LSP セットアップで旧 API を前提にしているため、将来の互換性が低い状態でした。

## 根本原因
`home/base/editor/neovim/plugins/lsp.nix` で各 LSP サーバーを次の形で初期化していました。
- `local lspconfig = require("lspconfig")`
- `lspconfig[server].setup(opt)`

この書き方は新しい Neovim / nvim-lspconfig の推奨経路ではなく、`vim.lsp.config` と `vim.lsp.enable` を使う移行先 API へ切り替える必要がありました。

## 修正内容
`home/base/editor/neovim/plugins/lsp.nix` の LSP 初期化ループを以下のように置き換えました。
- `vim.lsp.config(server, opt)`
- `vim.lsp.enable(server)`

既存の `capabilities` や `on_attach`、保存時フォーマットの挙動は維持しています。

## 検証
ローカルで以下を実施しました。
1. `darwin-rebuild build --flake .#M4MacBookAir`
2. 生成された Home Manager 側 `init.lua` に `vim.lsp.config` が含まれることを確認
3. 適用後に `rg -n 'require\("lspconfig"\)' ~/.config/nvim` でヒットしないことを確認

この変更により、起動時の非推奨警告は解消される想定です。
