### PR TITLE
add comma and nix-index-database for nix-locate support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,6 +142,26 @@
         "type": "github"
       }
     },
+    "nix-index-database": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1771130777,
+        "narHash": "sha256-UIKOwG0D9XVIJfNWg6+gENAvQP+7LO46eO0Jpe+ItJ0=",
+        "owner": "nix-community",
+        "repo": "nix-index-database",
+        "rev": "efec7aaad8d43f8e5194df46a007456093c40f88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-index-database",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1770537093,
@@ -180,6 +200,7 @@
         "llm-agents": "llm-agents",
         "neovim": "neovim",
         "nix-darwin": "nix-darwin",
+        "nix-index-database": "nix-index-database",
         "nixpkgs": "nixpkgs_2"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    nix-index-database = {
+      url = "github:nix-community/nix-index-database";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -40,6 +45,7 @@
       self,
       nixpkgs,
       nix-darwin,
+      nix-index-database,
       home-manager,
       neovim,
       llm-agents,
@@ -56,9 +62,13 @@
           system = "aarch64-darwin";
           modules = [
             ./hosts/M4MacBookAir
+            nix-index-database.darwinModules.nix-index
             home-manager.darwinModules.home-manager
             {
               home-manager.useGlobalPkgs = true;
+              home-manager.extraSpecialArgs = {
+                inherit inputs;
+              };
               home-manager.users.pranc1ngpegasus = import ./home/darwin;
             }
             {

--- a/home/base/programs/default.nix
+++ b/home/base/programs/default.nix
@@ -9,6 +9,7 @@
   home = {
     packages = with pkgs; [
       colima
+      comma
       docker
       docker-buildx
       docker-compose
@@ -18,6 +19,7 @@
       jq
       lazygit
       mmv-go
+      octorus
       ripgrep
     ];
   };

--- a/home/darwin/default.nix
+++ b/home/darwin/default.nix
@@ -1,7 +1,8 @@
-{ ... }:
+{ inputs, ... }:
 {
   imports = [
     ../base
+    inputs.nix-index-database.homeModules.nix-index
   ];
 
   home = {


### PR DESCRIPTION
## Summary
- nix-index-database を flake input に追加し、darwin モジュールと home-manager モジュールの両方を有効にした
- comma パッケージを追加し、nix-locate によるコマンド検索を利用できるようにした
- home-manager.extraSpecialArgs で inputs を渡すようにして、home-manager モジュールから flake input を参照できるようにした

## Test plan
- [ ] `darwin-rebuild switch --flake .#M4MacBookAir` でビルドが通ることを確認する
- [ ] `, bun` のようなコマンドで comma が正しく動作することを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)