### PR TITLE
[codex] Enable gh git credential helper

### DIFF
--- a/home/base/programs/git/default.nix
+++ b/home/base/programs/git/default.nix
@@ -24,6 +24,11 @@ in
       diff = {
         colorMoved = "default";
       };
+      credential = {
+        "https://github.com" = {
+          helper = "!gh auth git-credential";
+        };
+      };
       fetch = {
         prune = true;
         pruneTags = true;


### PR DESCRIPTION
## 変更内容
Home Manager で管理される Git 設定に、
`credential."https://github.com".helper = "!gh auth git-credential"`
を追加し、GitHub 向けの認証ヘルパーとして `gh` を直接参照するようにしました。

## 発生していた問題と原因
NixOS や nix-darwin のような宣言的管理環境では、`gh auth setup-git` が `.gitconfig` への期待される追記を
行いきれず、HTTPS 経由の GitHub 操作で認証情報ヘルパー設定が不足することがあります。

今回の差分は、`gh auth setup-git` 相当の設定を `programs.git.settings` に明示的に反映することで、
この環境差を吸収するための対応です。

## 効果
- `gh auth login` で認証済みの環境で、Git の HTTPS 認証が `gh auth git-credential` を使って安定します。
- `git` 側に追加の手動設定なしで、Nix 再生成後も設定を維持できます。

## テスト/検証
- ファイル差分の確認のみ。実機適用後に `gh auth git-credential` 利用時の GitHub 認証フローで動作確認する想定です。
