### PR TITLE
[codex] Enable sudo reattach for Touch ID recovery

### DIFF
--- a/modules/darwin/system.nix
+++ b/modules/darwin/system.nix
@@ -12,6 +12,7 @@
       services = {
         sudo_local = {
           touchIdAuth = true;
+          reattach = true;
         };
       };
     };


### PR DESCRIPTION
## 背景
`sudo` の認証で Touch ID が使えない場面がある、特に端末のセッション継続（tmux/screen など）時に `pam_tid.so` が期待どおり動作しないケースがありました。

## 原因
nix-darwin の `security.pam.services.sudo_local` で `touchIdAuth` は有効化されていたものの、`reattach` が未設定のため、再アタッチが必要な環境で認証が安定しませんでした。

## 対応内容
- `modules/darwin/system.nix` の `security.pam.services.sudo_local` に `reattach = true;` を追加。
- これにより、`pam-reattach` が有効化され、バックグラウンドやセッション遷移時でも Touch ID で sudo 認証が通りやすくなります。

## 検証
- `nix fmt` 実行済み
- 該当行の設定変更を反映済み（1 行追加）

## 影響範囲
- システム全体の `sudo` 認証フローに限定
- 利便性向上（Touch ID の認証成功率向上）が期待されるが、環境によっては一部挙動差があります
