### PR TITLE
refactor(flake): split modules by responsibility and slim flake.nix

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,10 +5,17 @@
 ```mermaid
 graph TD
     A[flake.nix] --> B[hosts/M4MacBookAir/default.nix]
-    B --> C[modules/darwin/default.nix]
-    C --> D[modules/default.nix]
-    C --> E[modules/darwin/system.nix]
-    A --> F[home/darwin/default.nix]
+    A --> C[modules/darwin/default.nix]
+    C --> D[modules/common/default.nix]
+    D --> D1[modules/common/nix.nix]
+    C --> E1[modules/darwin/environment.nix]
+    C --> E2[modules/darwin/fonts.nix]
+    C --> E3[modules/darwin/system-defaults.nix]
+    C --> E4[modules/darwin/security.nix]
+    C --> E5[modules/darwin/home-manager.nix]
+    C --> E6[modules/darwin/llm-agents.nix]
+    C --> E7[modules/darwin/neovim-overlay.nix]
+    E5 --> F[home/darwin/default.nix]
     F --> G[home/base/default.nix]
     G --> H[editor/neovim/]
     H --> L[neovim/plugins/]
@@ -21,25 +28,35 @@ graph TD
 
 ### flake.nix
 
-リポジトリ全体のエントリーポイントにあたる。nixpkgs, nix-darwin, home-manager, neovim-nightly-overlay などの inputs を定義し、darwinConfigurations を出力する。
+リポジトリ全体のエントリーポイントにあたる。nixpkgs, nix-darwin, home-manager, neovim-nightly-overlay, llm-agents などの inputs を定義し、`darwinConfigurations.M4MacBookAir` を出力する。出力本体は `./hosts/M4MacBookAir` と `./modules/darwin` を import するだけの薄い骨格にとどめ、具体的な設定は各モジュール側に集約している。
 
 ### hosts/
 
-マシンごとの設定を置く場所。hostname やユーザー名、home-manager との接続を定義する。新しいマシンを追加するときは `hosts/<hostname>/default.nix` を作成し、`flake.nix` の darwinConfigurations にエントリーを追加する。
+マシンごとのホスト固有設定を置く場所。`hostPlatform`、`hostName`、`primaryUser`、`stateVersion`、ユーザーアカウントなど、そのホストに紐づく情報だけを持つ。新しいマシンを追加するときは `hosts/<hostname>/default.nix` を作成し、`flake.nix` の `darwinConfigurations` にエントリーを追加する。
 
 ### modules/
 
-nix-darwin のシステムレベル設定をまとめている。`modules/default.nix` は Nix 自体の基本設定 (flakes 有効化、unfree 許可、タイムゾーン) を担当し、`modules/darwin/system.nix` は macOS 固有のシステム設定 (firewall, keyboard remap, dock, finder 等) を担当する。
+nix-darwin のシステムレベル設定を責務ごとに分割している。
+
+- `modules/common/` は Nix 自体の基本設定を担当する。`nix.nix` に nix.enable、unfree 許可、タイムゾーンなどプラットフォーム非依存の設定をまとめている
+- `modules/darwin/` は macOS 固有の設定を責務単位のファイルに分割している
+  - `environment.nix` は `environment.pathsToLink` と `environment.shells` を設定する
+  - `fonts.nix` は `fonts.packages` で Nerd Fonts をインストールする
+  - `system-defaults.nix` は `system.defaults.*` (NSGlobalDomain, dock, finder, trackpad, menuExtraClock) を設定する
+  - `security.nix` は Application Firewall、Touch ID による sudo 認証、Caps Lock のリマップを設定する
+  - `home-manager.nix` は home-manager の nix-darwin 統合 (`useGlobalPkgs`, `backupFileExtension`, `extraSpecialArgs`, ユーザーエントリ) を定義する
+  - `llm-agents.nix` は nix-index-database モジュールの import と `claude-code` の systemPackages への注入を担当する
+  - `neovim-overlay.nix` は neovim-nightly-overlay を `nixpkgs.overlays` に追加し、`pkgs.neovim-unwrapped` を nightly ビルドに差し替える
 
 ### home/base/
 
 全プラットフォーム共通のユーザー環境設定を置く場所で、以下のサブモジュールを持つ。
 
 - `editor/neovim/` は Neovim nightly に LSP (gopls, nil, rust-analyzer, typescript-language-server) と各種プラグインを組み合わせた設定を管理している。プラグイン定義は `plugins/` サブディレクトリに分割されており、ui, completion, lsp, tools の 4 カテゴリで構成されている
-- `programs/` はパッケージ一覧 (`default.nix`) と、atuin, direnv, fzf, git, ssh といった個別ツールの設定を管理している
+- `programs/` は個別ツールの設定を管理している。`default.nix` はサブモジュールを束ねる import list のみ、`packages.nix` が CLI パッケージ一覧 (`home.packages`) を保持する。サブモジュールとして atuin, direnv, fzf, git, ssh が並ぶ
 - `shell/bash/` は Bash の設定を管理している。history は atuin が、Ctrl+G / Ctrl+W の fuzzy cd は fzf-tmux が担う
 - `terminal/tmux/` は Tmux の設定を管理している (prefix は C-q)
 
 ### home/darwin/
 
-darwin 固有の home-manager 設定を置く場所。state version と linkapps の設定を行い、`home/base/` を import している。
+darwin 固有の home-manager 設定を置く場所。state version と linkApps の設定を行い、`home/base/` を import している。

--- a/flake.nix
+++ b/flake.nix
@@ -42,43 +42,21 @@
 
   outputs =
     {
-      self,
       nixpkgs,
       nix-darwin,
-      nix-index-database,
-      home-manager,
-      neovim,
-      llm-agents,
       ...
     }@inputs:
-    let
-      inherit (self) outputs;
-    in
     {
       formatter.aarch64-darwin = nixpkgs.legacyPackages.aarch64-darwin.nixfmt-tree;
-      packages.aarch64-darwin.neovim = inputs.neovim.packages.aarch64-darwin.default;
+
       darwinConfigurations = {
         M4MacBookAir = nix-darwin.lib.darwinSystem {
-          system = "aarch64-darwin";
           modules = [
             ./hosts/M4MacBookAir
-            nix-index-database.darwinModules.nix-index
-            home-manager.darwinModules.home-manager
-            {
-              home-manager.useGlobalPkgs = true;
-              home-manager.extraSpecialArgs = {
-                inherit inputs;
-              };
-              home-manager.users.pranc1ngpegasus = import ./home/darwin;
-            }
-            {
-              environment.systemPackages = with llm-agents.packages.aarch64-darwin; [
-                claude-code
-              ];
-            }
+            ./modules/darwin
           ];
           specialArgs = {
-            inherit inputs outputs;
+            inherit inputs;
           };
         };
       };

--- a/home/base/programs/default.nix
+++ b/home/base/programs/default.nix
@@ -1,27 +1,10 @@
-{ pkgs, ... }:
 {
   imports = [
+    ./packages.nix
     ./atuin
     ./direnv
     ./fzf
     ./git
     ./ssh
   ];
-  home = {
-    packages = with pkgs; [
-      colima
-      comma
-      docker
-      docker-buildx
-      docker-compose
-      gh
-      ghq
-      httpie
-      jq
-      lazygit
-      mmv-go
-      octorus
-      ripgrep
-    ];
-  };
 }

--- a/home/base/programs/packages.nix
+++ b/home/base/programs/packages.nix
@@ -1,0 +1,20 @@
+{ pkgs, ... }:
+{
+  home = {
+    packages = with pkgs; [
+      colima
+      comma
+      docker
+      docker-buildx
+      docker-compose
+      gh
+      ghq
+      httpie
+      jq
+      lazygit
+      mmv-go
+      octorus
+      ripgrep
+    ];
+  };
+}

--- a/hosts/M4MacBookAir/default.nix
+++ b/hosts/M4MacBookAir/default.nix
@@ -1,9 +1,8 @@
 { pkgs, ... }:
+let
+  user = "pranc1ngpegasus";
+in
 {
-  imports = [
-    ../../modules/darwin
-  ];
-
   nixpkgs = {
     hostPlatform = "aarch64-darwin";
   };
@@ -13,12 +12,13 @@
   };
 
   system = {
-    primaryUser = "pranc1ngpegasus";
+    primaryUser = user;
+    stateVersion = 5;
   };
 
-  users.users.pranc1ngpegasus = {
-    name = "pranc1ngpegasus";
-    home = "/Users/pranc1ngpegasus";
+  users.users.${user} = {
+    name = user;
+    home = "/Users/${user}";
     shell = pkgs.bashInteractive;
   };
 }

--- a/modules/common/default.nix
+++ b/modules/common/default.nix
@@ -1,0 +1,5 @@
+{
+  imports = [
+    ./nix.nix
+  ];
+}

--- a/modules/common/nix.nix
+++ b/modules/common/nix.nix
@@ -1,4 +1,3 @@
-{ ... }:
 {
   nix = {
     enable = false;

--- a/modules/darwin/default.nix
+++ b/modules/darwin/default.nix
@@ -1,22 +1,12 @@
-{ pkgs, ... }:
 {
   imports = [
-    ../default.nix
-    ./system.nix
+    ../common
+    ./environment.nix
+    ./fonts.nix
+    ./system-defaults.nix
+    ./security.nix
+    ./home-manager.nix
+    ./llm-agents.nix
+    ./neovim-overlay.nix
   ];
-
-  environment = {
-    pathsToLink = [ "/Applications" ];
-    shells = [ pkgs.bashInteractive ];
-  };
-
-  fonts = {
-    packages = [
-      pkgs.nerd-fonts.jetbrains-mono
-    ];
-  };
-
-  system = {
-    stateVersion = 5;
-  };
 }

--- a/modules/darwin/environment.nix
+++ b/modules/darwin/environment.nix
@@ -1,0 +1,7 @@
+{ pkgs, ... }:
+{
+  environment = {
+    pathsToLink = [ "/Applications" ];
+    shells = [ pkgs.bashInteractive ];
+  };
+}

--- a/modules/darwin/fonts.nix
+++ b/modules/darwin/fonts.nix
@@ -1,0 +1,8 @@
+{ pkgs, ... }:
+{
+  fonts = {
+    packages = [
+      pkgs.nerd-fonts.jetbrains-mono
+    ];
+  };
+}

--- a/modules/darwin/home-manager.nix
+++ b/modules/darwin/home-manager.nix
@@ -1,0 +1,15 @@
+{ inputs, ... }:
+{
+  imports = [
+    inputs.home-manager.darwinModules.home-manager
+  ];
+
+  home-manager = {
+    useGlobalPkgs = true;
+    backupFileExtension = "hm-backup";
+    extraSpecialArgs = {
+      inherit inputs;
+    };
+    users.pranc1ngpegasus = import ../../home/darwin;
+  };
+}

--- a/modules/darwin/llm-agents.nix
+++ b/modules/darwin/llm-agents.nix
@@ -1,0 +1,12 @@
+{ inputs, pkgs, ... }:
+{
+  imports = [
+    inputs.nix-index-database.darwinModules.nix-index
+  ];
+
+  environment = {
+    systemPackages = [
+      inputs.llm-agents.packages.${pkgs.system}.claude-code
+    ];
+  };
+}

--- a/modules/darwin/neovim-overlay.nix
+++ b/modules/darwin/neovim-overlay.nix
@@ -1,0 +1,8 @@
+{ inputs, ... }:
+{
+  nixpkgs = {
+    overlays = [
+      inputs.neovim.overlays.default
+    ];
+  };
+}

--- a/modules/darwin/security.nix
+++ b/modules/darwin/security.nix
@@ -1,0 +1,25 @@
+{
+  networking = {
+    applicationFirewall = {
+      enable = true;
+      blockAllIncoming = true;
+    };
+  };
+
+  security = {
+    pam = {
+      services = {
+        sudo_local = {
+          touchIdAuth = true;
+        };
+      };
+    };
+  };
+
+  system = {
+    keyboard = {
+      enableKeyMapping = true;
+      remapCapsLockToControl = true;
+    };
+  };
+}

--- a/modules/darwin/system-defaults.nix
+++ b/modules/darwin/system-defaults.nix
@@ -1,28 +1,5 @@
-{ ... }:
 {
-  networking = {
-    applicationFirewall = {
-      enable = true;
-      blockAllIncoming = true;
-    };
-  };
-
-  security = {
-    pam = {
-      services = {
-        sudo_local = {
-          touchIdAuth = true;
-        };
-      };
-    };
-  };
-
   system = {
-    keyboard = {
-      enableKeyMapping = true;
-      remapCapsLockToControl = true;
-    };
-
     defaults = {
       NSGlobalDomain = {
         "com.apple.trackpad.scaling" = 3.0;


### PR DESCRIPTION
## Summary

- flake.nix を薄化し、`darwinConfigurations.M4MacBookAir` は `./hosts/M4MacBookAir` と `./modules/darwin` を import するだけの骨格にする。home-manager 統合と llm-agents の systemPackages 注入は `modules/darwin/home-manager.nix`, `modules/darwin/llm-agents.nix` に切り出した
- `modules/default.nix` を `modules/common/` に移し、`modules/darwin/system.nix` を `system-defaults.nix` と `security.nix` に分割。新たに `environment.nix` と `fonts.nix` も独立ファイル化し、1 ファイル 1 責務に揃えた
- `neovim-nightly-overlay` を `nixpkgs.overlays` に実際に適用する `modules/darwin/neovim-overlay.nix` を追加。これにより `home/base/editor/neovim/default.nix` の `pkgs.neovim-unwrapped` が nightly に差し替わり、docs の説明と実装が一致する
- `hosts/M4MacBookAir/default.nix` に `stateVersion` を移動し、user 名を `let` 束縛で集約
- `home/base/programs/default.nix` から CLI パッケージ一覧を `packages.nix` に分離し、`default.nix` は import list のみに
- home-manager 統合に `backupFileExtension = "hm-backup"` を追加
- `flake.nix` から未使用の `outputs` 束縛、二重定義だった `system = "aarch64-darwin"` 引数、未使用の `packages.aarch64-darwin.neovim` を削除
- docs/architecture.md を新しい構造に合わせて更新

## Test plan

- [x] `nix fmt` が差分なしで完了
- [x] `nix flake check --no-build` が `darwinConfigurations.M4MacBookAir` を評価成功
- [ ] `darwin-rebuild build --flake .#M4MacBookAir` が成功
- [ ] `nix store diff-closures /run/current-system ./result` で意図しない差分がないことを確認
- [ ] `darwin-rebuild switch` 後に `nvim --version` が nightly ビルドを指すこと
- [ ] `claude-code`, `ghq`, `fzf`, `ghostty` が従来通り動作すること
- [ ] `system.defaults` 由来の挙動 (dock autohide, finder カラム表示等) が維持されていること

Generated with [Claude Code](https://claude.com/claude-code)