### PR TITLE
feat(programs): manage secrets with sops + age-plugin-se

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ nix fmt
 - Docker ランタイムには colima を使用している
 - パッケージ一覧は `home/base/programs/default.nix` に集約している
 - Nix コードのフォーマットには nixfmt を使用している
+- プロジェクトの開発環境変数は sops + age + age-plugin-se で暗号化し、Secure Enclave に鍵を委ねている。direnv stdlib に `use sops` を生やしているので `.envrc` から呼び出せる。詳細は [docs/secrets.md](docs/secrets.md) を参照
 
 ## Conventions
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,7 +53,7 @@ nix-darwin のシステムレベル設定を責務ごとに分割している。
 全プラットフォーム共通のユーザー環境設定を置く場所で、以下のサブモジュールを持つ。
 
 - `editor/neovim/` は Neovim nightly に LSP (gopls, nil, rust-analyzer, typescript-language-server) と各種プラグインを組み合わせた設定を管理している。プラグイン定義は `plugins/` サブディレクトリに分割されており、ui, completion, lsp, tools の 4 カテゴリで構成されている
-- `programs/` は個別ツールの設定を管理している。`default.nix` はサブモジュールを束ねる import list のみ、`packages.nix` が CLI パッケージ一覧 (`home.packages`) を保持する。サブモジュールとして atuin, direnv, fzf, git, ssh が並ぶ
+- `programs/` は個別ツールの設定を管理している。`default.nix` はサブモジュールを束ねる import list のみ、`packages.nix` が CLI パッケージ一覧 (`home.packages`) を保持する。サブモジュールとして atuin, direnv, fzf, git, sops, ssh が並ぶ。`sops/` は sops、age、age-plugin-se の導入と direnv stdlib への `use sops` ヘルパー追加を担当する
 - `shell/bash/` は Bash の設定を管理している。history は atuin が、Ctrl+G / Ctrl+W の fuzzy cd は fzf-tmux が担う
 - `terminal/tmux/` は Tmux の設定を管理している (prefix は C-q)
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,81 @@
+# 開発環境変数の管理
+
+このドキュメントでは、sops と age、そして Apple Secure Enclave に鍵を委ねる age-plugin-se を組み合わせて、プロジェクトごとの開発環境変数を安全に持ち運ぶ手順をまとめる。
+
+## 全体像
+
+```mermaid
+graph LR
+    A[secrets.sops.yaml] -->|sops decrypt| B[plaintext dotenv]
+    B -->|direnv use sops| C[shell env]
+    D[~/.config/sops/age/keys.txt] -->|identity| A
+    E[Secure Enclave] -->|biometry| D
+```
+
+リポジトリには sops で暗号化したファイル (`secrets.sops.yaml` など) のみをコミットし、復号鍵そのものはマシン外には出ない。直接の復号鍵は Secure Enclave に格納されており、`~/.config/sops/age/keys.txt` にはそのハンドルだけが置かれる。Touch ID で認証するたびに Secure Enclave 内で復号が行われ、平文の鍵はメモリ上にも残らない。
+
+## 提供されるもの
+
+`home/base/programs/sops/default.nix` が次の 3 点を提供する。
+
+- `sops`、`age`、`age-plugin-se` の 3 つの CLI を `home.packages` でインストールする
+- `SOPS_AGE_KEY_FILE` を `~/.config/sops/age/keys.txt` に固定する `home.sessionVariables` を設定する
+- direnv の stdlib に `use_sops` ヘルパーを追加し、`.envrc` から `use sops` で呼び出せるようにする
+
+## 初期セットアップ
+
+新しいマシンでは、age-plugin-se で identity を生成する必要がある。1 度きりの作業なので flake では自動化していない。
+
+```bash
+mkdir -p ~/.config/sops/age
+age-plugin-se keygen \
+  --access-control any-biometry-and-passcode \
+  -o ~/.config/sops/age/keys.txt
+```
+
+`--access-control` の選択肢はいくつかあるが、ここでは Touch ID と passcode の両方を要求する `any-biometry-and-passcode` を推奨する。生成された `keys.txt` の冒頭コメントには対応する公開鍵 (`age1se1...` で始まる recipient) が記載されている。これが暗号化先の宛先になる。
+
+`keys.txt` は Secure Enclave への参照しか持たないが、コミットすると鍵の利用範囲が広がってしまうため commit してはいけない。
+
+## プロジェクトでの使い方
+
+### 1. リポジトリ直下に `.sops.yaml` を置く
+
+```yaml
+creation_rules:
+  - path_regex: secrets\.sops\.ya?ml$
+    age: age1se1qg... # age-plugin-se で生成した recipient をここに貼る
+```
+
+複数の開発者で共有する場合は、各人の recipient を `age:` にカンマ区切りで列挙する。
+
+### 2. `secrets.sops.yaml` を作って暗号化する
+
+```bash
+sops edit secrets.sops.yaml
+```
+
+エディタが開くので、平文の dotenv 形式ではなく YAML として平坦に書く。
+
+```yaml
+DATABASE_URL: postgres://...
+API_KEY: xxx
+```
+
+保存すると sops が自動で暗号化し、ファイル内の各 value だけが ENC[AES256_GCM,...] に置き換わる。キー名と構造は平文のままなので diff が読みやすい。
+
+### 3. `.envrc` で読み込む
+
+```bash
+use sops
+# あるいは明示的にパスを指定する
+# use sops secrets.sops.yaml
+```
+
+`direnv allow` すると、cd した瞬間に Touch ID プロンプトが出て、復号された値が環境変数として export される。`secrets.sops.yaml` を `watch_file` しているので、暗号化ファイルを更新すれば自動で再読み込みされる。
+
+## 持ち運びと共有
+
+- 暗号化済みファイル (`secrets.sops.yaml`, `.sops.yaml`) はそのまま VCS にコミットして問題ない
+- 別マシンで開発する場合は、そのマシンでも `age-plugin-se keygen` を行って recipient を `.sops.yaml` に追記し、`sops updatekeys secrets.sops.yaml` で再暗号化する
+- recipient を失効させたい場合は `.sops.yaml` から削除し、同じく `sops updatekeys` を走らせる

--- a/home/base/programs/default.nix
+++ b/home/base/programs/default.nix
@@ -5,6 +5,7 @@
     ./direnv
     ./fzf
     ./git
+    ./sops
     ./ssh
   ];
 }

--- a/home/base/programs/sops/default.nix
+++ b/home/base/programs/sops/default.nix
@@ -1,0 +1,52 @@
+{ config, pkgs, ... }:
+{
+  home = {
+    packages = with pkgs; [
+      sops
+      age
+      age-plugin-se
+    ];
+
+    # sops が age 識別ファイルを探す場所を XDG 配下に固定する。
+    # age-plugin-se で生成した identity (Secure Enclave へのハンドル) をここに置く。
+    sessionVariables = {
+      SOPS_AGE_KEY_FILE = "${config.home.homeDirectory}/.config/sops/age/keys.txt";
+    };
+  };
+
+  # direnv stdlib に `use sops` を生やす。
+  # プロジェクトの `.envrc` に `use sops` と書くだけで、暗号化された
+  # secrets ファイルを復号して環境変数として export できる。
+  programs.direnv.stdlib = ''
+    # use_sops [path]
+    #   sops で暗号化された YAML/JSON/dotenv を復号し、direnv の dotenv loader に流し込む。
+    #   path を省略した場合は secrets.sops.yaml を見る。
+    use_sops() {
+      local path=''${1:-secrets.sops.yaml}
+      if [[ ! -f "$path" ]]; then
+        log_error "use sops: file not found: $path"
+        return 1
+      fi
+      watch_file "$path"
+
+      local fmt
+      case "$path" in
+        *.json) fmt=json ;;
+        *.yaml | *.yml) fmt=yaml ;;
+        *) fmt=dotenv ;;
+      esac
+
+      # 平文を fs に落とす時間を最小化するため、TMPDIR (mktemp は mode 600) を経由して
+      # direnv の dotenv loader に渡したあとすぐに削除する。
+      local tmpfile
+      tmpfile=$(mktemp -t direnv-sops.XXXXXX) || return 1
+      if ! sops decrypt --input-type "$fmt" --output-type dotenv "$path" > "$tmpfile"; then
+        rm -f "$tmpfile"
+        log_error "use sops: failed to decrypt $path"
+        return 1
+      fi
+      dotenv "$tmpfile"
+      rm -f "$tmpfile"
+    }
+  '';
+}

--- a/home/base/programs/sops/default.nix
+++ b/home/base/programs/sops/default.nix
@@ -29,6 +29,15 @@
       fi
       watch_file "$path"
 
+      # SOPS_AGE_KEY_FILE は home.sessionVariables でも設定しているが、
+      # darwin-rebuild 直後に shell を reload していない場合や、direnv が継承する
+      # 環境にまだ反映されていない場合に備えて、関数内でも同じ既定値を補う。
+      local key_file=''${SOPS_AGE_KEY_FILE:-$HOME/.config/sops/age/keys.txt}
+      if [[ ! -f "$key_file" ]]; then
+        log_error "use sops: age identity not found at $key_file. Generate one with: age-plugin-se keygen --access-control any-biometry-and-passcode -o $key_file"
+        return 1
+      fi
+
       local fmt
       case "$path" in
         *.json) fmt=json ;;
@@ -40,7 +49,7 @@
       # direnv の dotenv loader に渡したあとすぐに削除する。
       local tmpfile
       tmpfile=$(mktemp -t direnv-sops.XXXXXX) || return 1
-      if ! sops decrypt --input-type "$fmt" --output-type dotenv "$path" > "$tmpfile"; then
+      if ! SOPS_AGE_KEY_FILE="$key_file" sops decrypt --input-type "$fmt" --output-type dotenv "$path" > "$tmpfile"; then
         rm -f "$tmpfile"
         log_error "use sops: failed to decrypt $path"
         return 1


### PR DESCRIPTION
## Summary

開発環境変数を sops で暗号化し、age + age-plugin-se 経由で Apple Secure Enclave に鍵を委ねた状態で運用できるようにする。プロジェクトの `.envrc` から `use sops` と書くだけで Touch ID 認証つきで復号され、平文の値が環境変数として export される。

- `sops`、`age`、`age-plugin-se` の 3 つを `home.packages` に追加する
- `SOPS_AGE_KEY_FILE` を `~/.config/sops/age/keys.txt` に固定する
- direnv stdlib に `use_sops` ヘルパーを追加し、`.envrc` で `use sops [path]` を使えるようにする
- 運用手順を `docs/secrets.md` にまとめ、`AGENTS.md` と `docs/architecture.md` から参照する

## 仕組み

```mermaid
graph LR
    A[secrets.sops.yaml] -->|sops decrypt| B[plaintext dotenv]
    B -->|direnv use sops| C[shell env]
    D[~/.config/sops/age/keys.txt] -->|identity| A
    E[Secure Enclave] -->|biometry| D
```

Secure Enclave に格納された秘密鍵そのものはマシン外に出ない。`keys.txt` には Secure Enclave へのハンドルだけが入っており、復号のたびに Touch ID で認証される。リポジトリには暗号化済みの `secrets.sops.yaml` と `.sops.yaml` だけをコミットする。

## Test plan

- [ ] `darwin-rebuild build --flake .#M4MacBookAir` がエラーなく通る
- [ ] `darwin-rebuild switch` 後に `sops`、`age`、`age-plugin-se` が PATH に居る
- [ ] `age-plugin-se keygen --access-control any-biometry-and-passcode -o ~/.config/sops/age/keys.txt` で identity を生成できる
- [ ] テスト用プロジェクトで `secrets.sops.yaml` を作り、`.envrc` に `use sops` を書いたうえで `direnv allow` すると Touch ID プロンプトが出て、復号値が環境変数として読まれる
- [ ] 暗号化ファイルを書き換えると direnv が自動で再読み込みする


---
_Generated by [Claude Code](https://claude.ai/code/session_01MREAGh2ZuMfx5k2yxAqLGZ)_