### PR TITLE
ci(dependabot): weekly nix flake updates with build-gated auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: nix
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      flake-inputs:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(flake)"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,39 @@
+name: dependabot-auto-merge
+
+# Dependabot が開いた flake.lock 更新 PR を、ビルドが通った場合にだけ自動マージする。
+on:
+  pull_request: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  # darwin システムをビルドして、更新後の flake.lock で構成が壊れていないか検証する
+  build:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    # aarch64-darwin 構成をビルドするため Apple Silicon の macOS ランナーを使う
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Build darwin configuration
+        run: |
+          nix build --accept-flake-config --print-build-logs \
+            '.#darwinConfigurations.M4MacBookAir.system'
+
+  # ビルド job が成功したときだけ実行される (needs により gate される)
+  merge:
+    needs: build
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Squash merge the PR
+        run: gh pr merge --squash --delete-branch "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要

Dependabot で flake input を weekly 更新し、ビルドが通った場合にだけ自動マージする仕組みを追加する。

GitHub Dependabot は 2026-04-07 に Nix エコシステムを正式サポート (GA) した。本リポジトリは public なので version updates の対象になる。

## 変更内容

### `.github/dependabot.yml`
- `package-ecosystem: nix` / `directory: /` で flake.lock を監視する
- `schedule.interval: weekly` で毎週更新する
- `groups` で全 flake input をまとめて 1 つの PR にする
- `commit-message.prefix: chore(flake)` で既存の Conventional Commits 規約に揃える

### `.github/workflows/dependabot-auto-merge.yml`
- `build` job: `macos-14` (Apple Silicon) で `nix build .#darwinConfigurations.M4MacBookAir.system` を実行し、更新後の flake.lock で構成が壊れていないか検証する
- `merge` job: `needs: build` で連結し、ビルド成功時のみ squash マージする
- ブランチ保護を使わずワークフロー内の `needs` でゲートするため、master への直接 push 運用を縛らない

## 備考

- Dependabot 本体に auto-merge 設定キーは無いため、マージは Actions 側で実現している
- public repo なので macOS ランナーを含め GitHub Actions は無料枠で利用できる
- これらの設定はデフォルトブランチ (master) にマージされて初めて有効になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)