### PR TITLE
ci(dependabot): run nix flake updates daily instead of weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: nix
     directory: /
     schedule:
-      interval: weekly
+      interval: daily
     groups:
       flake-inputs:
         patterns:


### PR DESCRIPTION
## Summary

- Dependabot の Nix flake 更新スケジュールを `weekly` から `daily` に変更する
- グループ化と auto-merge の設定はそのまま維持する

## Test plan

- [ ] `.github/dependabot.yml` の `schedule.interval` が `daily` になっていることを確認する
- [ ] マージ後、次の Dependabot 実行で daily スケジュールが反映されることを確認する


Made with [Cursor](https://cursor.com)