### PR TITLE
ci: ワークフローを整理し master push で FlakeHub Cache を残す

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,21 +1,28 @@
-name: dependabot-auto-merge
+name: ci
 on:
   pull_request: {}
+  push:
+    branches:
+      - master
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 jobs:
   build:
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-nix
       - run: nix build --accept-flake-config --print-build-logs '.#darwinConfigurations.M4MacBookAir.system'
-  merge:
+  dependabot-auto-merge:
     needs: build
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - run: gh pr merge --squash --delete-branch "$PR_URL"
         env:


### PR DESCRIPTION
## 概要

`.github/workflows` を整理し、main マージ時に FlakeHub Cache が確実に残るようにした。

## 変更内容

- `dependabot-auto-merge.yml` を削除し `ci.yml` に統合
- `push: master` トリガーを追加し、master への push でもビルドを実行
- マージジョブは `needs: build` かつ `pull_request` の Dependabot PR のときだけ実行
- permissions を最小化 (トップレベル `contents: read`、書き込みはマージジョブに job 単位で付与)
- 同一 ref の古い実行をキャンセルする concurrency を追加

## 背景

旧設定はビルドジョブが Dependabot PR のときだけ走っていた。Dependabot や fork の PR では GitHub token が read-only になり `flakehub-cache-action` のキャッシュ書き込みに失敗しやすいため、default branch のクロージャがキャッシュに残らなかった。full token を持つ master への push でビルドを走らせることで、FlakeHub Cache に確実に push されるようにした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)