### PR TITLE
ci: build ジョブに id-token: write を付与

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   build:
     runs-on: macos-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-nix


### PR DESCRIPTION
## 概要

FlakeHub Cache の OIDC 認証のため、build ジョブに `id-token: write` を付与する。

## 背景

`flakehub-cache-action` は GitHub の OIDC トークンで FlakeHub に認証するため、`id-token: write` 権限が必要。これがないとキャッシュの push が認証エラーで失敗する。

## 注意

このPRは #37 を base にしたスタックPR。#37 で新規作成する `ci.yml` への追記のため、#37 を先にマージするか、#37 マージ後に base を master へ付け替えること。

🤖 Generated with [Claude Code](https://claude.com/claude-code)