### PR TITLE
[codex] Ghostty を管理外ツール一覧から削除

### DIFF
--- a/docs/non-flake-tools.md
+++ b/docs/non-flake-tools.md
@@ -25,13 +25,6 @@
 - 公式: https://choosy.app/
 - インストール: macOS アプリとして手動インストール
 
-## Ghostty
-
-- 用途: GPU アクセラレーション対応のターミナルエミュレータ
-- 詳細: macOS では Metal によるGPU レンダリングを使用。プラットフォームネイティブな UI、タブ・分割ペイン、Kitty graphics/keyboard protocol、Nerd Fonts のビルトインサポートなどを備える
-- 公式: https://ghostty.org/
-- インストール: macOS アプリとして手動インストール
-
 ## Karabiner-Elements
 
 - 用途: macOS 向けキーボードカスタマイズツール


### PR DESCRIPTION
## 概要

docs/non-flake-tools.md から Ghostty の節を削除しました。
Ghostty は home/darwin/programs/ghostty/default.nix で Home Manager 管理になっているため、管理外ツールとして案内しないようにしています。

## 影響

手動インストールが必要なツール一覧が、現在の構成と一致するようになります。

## 確認

ドキュメントのみの変更のため、テストは実行していません。